### PR TITLE
BCF reader

### DIFF
--- a/oxbow/Cargo.lock
+++ b/oxbow/Cargo.lock
@@ -626,6 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc3e1a97106b94104db416d3886594b2f4d7c49cdf90603b68ea4d71833b2b5"
 dependencies = [
  "noodles-bam",
+ "noodles-bcf",
  "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
@@ -648,6 +649,20 @@ dependencies = [
  "noodles-csi",
  "noodles-fasta",
  "noodles-sam",
+]
+
+[[package]]
+name = "noodles-bcf"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4238d1e714389fc4121efa3f5422e4810de051498733573fefc02ea8ad33231"
+dependencies = [
+ "byteorder",
+ "indexmap",
+ "noodles-bgzf",
+ "noodles-core",
+ "noodles-csi",
+ "noodles-vcf",
 ]
 
 [[package]]

--- a/oxbow/Cargo.lock
+++ b/oxbow/Cargo.lock
@@ -841,6 +841,7 @@ name = "oxbow"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "byteorder",
  "noodles",
 ]
 

--- a/oxbow/Cargo.toml
+++ b/oxbow/Cargo.toml
@@ -8,4 +8,5 @@ description = "Read specialized bioinformatic file formats as data frames in R, 
 
 [dependencies]
 arrow = "37.0.0"
+byteorder = "1.4.3"
 noodles = { version = "0.35.0", features = ["bam", "bcf", "bgzf", "core", "sam", "csi", "vcf", "tabix"] }

--- a/oxbow/Cargo.toml
+++ b/oxbow/Cargo.toml
@@ -8,4 +8,4 @@ description = "Read specialized bioinformatic file formats as data frames in R, 
 
 [dependencies]
 arrow = "37.0.0"
-noodles = { version = "0.35.0", features = ["bam", "bgzf", "core", "sam", "csi", "vcf", "tabix"] }
+noodles = { version = "0.35.0", features = ["bam", "bcf", "bgzf", "core", "sam", "csi", "vcf", "tabix"] }

--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -2,7 +2,6 @@ use arrow::array::{
     ArrayRef, GenericStringBuilder, Int32Array, Int32Builder, StringArray, StringDictionaryBuilder,
     UInt16Array, UInt16Builder, UInt8Array, UInt8Builder,
 };
-
 use arrow::{
     datatypes::Int32Type, error::ArrowError, record_batch::RecordBatch,
 };

--- a/oxbow/src/bcf.rs
+++ b/oxbow/src/bcf.rs
@@ -1,0 +1,149 @@
+use arrow::array::{
+    ArrayRef, Float32Builder, GenericStringBuilder, Int32Builder,
+    StringArray, StringDictionaryBuilder,
+};
+use arrow::{
+    datatypes::Int32Type, error::ArrowError, record_batch::RecordBatch,
+};
+use noodles::core::Region;
+use noodles::bcf::header::StringMaps;
+use noodles::{bcf, bgzf, csi, vcf};
+use std::sync::Arc;
+
+use crate::batch_builder::{write_ipc, BatchBuilder};
+
+
+type BufferedReader = std::io::BufReader<std::fs::File>;
+
+/// A BCF reader.
+pub struct BcfReader {
+    reader: bcf::Reader<bgzf::Reader<BufferedReader>>,
+    header: vcf::Header,
+    string_maps: StringMaps,
+    index: csi::Index,
+}
+
+impl BcfReader {
+    /// Creates a BCF Reader.
+    pub fn new(path: &str) -> std::io::Result<Self> {
+        let index = csi::read(format!("{}.csi", path))?;
+        let file = std::fs::File::open(path)?;
+        let bufreader = std::io::BufReader::with_capacity(1024 * 1024, file);
+        let mut reader = bcf::Reader::new(bufreader);
+        let raw_header = reader.read_header()?;
+        let header = vcf::header::Parser::default()
+            .parse(&raw_header)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let string_maps = StringMaps::try_from(&header)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        Ok(Self { reader, header, string_maps, index })
+    }
+
+    /// Returns the records in the given region as Apache Arrow IPC.
+    ///
+    /// If the region is `None`, all records are returned.
+    ///
+    /// # Examples
+    ///
+    /// ``no_run
+    /// use oxbow::bcf::BcfReader;
+    ///
+    /// let mut reader = BcfReader::new("sample.bcf").unwrap();
+    /// let ipc = reader.records_to_ipc(Some("sq0:1-1000")).unwrap();
+    /// ```
+    pub fn records_to_ipc(&mut self, region: Option<&str>) -> Result<Vec<u8>, ArrowError> {
+        let batch_builder = BcfBatchBuilder::new(1024, &self.header, &self.string_maps)?;
+        let string_maps = StringMaps::from(&self.header);
+        if let Some(region) = region {
+            let region: Region = region.parse().unwrap();
+            let query = self
+                .reader
+                .query(string_maps.contigs(), &self.index, &region)
+                .unwrap()
+                .map(|r| r.unwrap());
+            return write_ipc(query, batch_builder);
+        }
+        let records = self.reader.records().map(|r| r.unwrap());
+        write_ipc(records, batch_builder)
+    }
+}
+
+struct BcfBatchBuilder {
+    chrom: StringDictionaryBuilder<Int32Type>,
+    pos: Int32Builder,
+    id: GenericStringBuilder<i32>,
+    ref_: GenericStringBuilder<i32>,
+    alt: GenericStringBuilder<i32>,
+    qual: Float32Builder,
+    filter: GenericStringBuilder<i32>,
+    info: GenericStringBuilder<i32>,
+    format: GenericStringBuilder<i32>,
+    header: vcf::Header,
+    string_maps: StringMaps,
+}
+
+impl BcfBatchBuilder {
+    pub fn new(capacity: usize, header: &vcf::Header, string_maps: &StringMaps) -> Result<Self, ArrowError> {
+        let categories = StringArray::from(
+            header
+                .contigs()
+                .keys()
+                .map(|k| k.to_string())
+                .collect::<Vec<_>>(),
+        );
+        Ok(Self {
+            chrom: StringDictionaryBuilder::<Int32Type>::new_with_dictionary(
+                capacity,
+                &categories,
+            )?,
+            pos: Int32Builder::with_capacity(capacity),
+            id: GenericStringBuilder::<i32>::new(),
+            ref_: GenericStringBuilder::<i32>::new(),
+            alt: GenericStringBuilder::<i32>::new(),
+            qual: Float32Builder::with_capacity(capacity),
+            filter: GenericStringBuilder::<i32>::new(),
+            info: GenericStringBuilder::<i32>::new(),
+            format: GenericStringBuilder::<i32>::new(),
+            header: header.clone(),
+            string_maps: string_maps.clone(),
+        })
+    }
+}
+
+impl BatchBuilder for BcfBatchBuilder {
+    type Record = bcf::record::Record;
+
+    fn push(&mut self, record: &Self::Record) {
+
+        let vcf_record = record.try_into_vcf_record(
+            &self.header, &self.string_maps
+        ).unwrap();
+
+        self.chrom.append_value(vcf_record.chromosome().to_string());
+        self.pos.append_value(usize::from(vcf_record.position()) as i32);
+        self.id.append_value(vcf_record.ids().to_string());
+        self.ref_.append_value(vcf_record.reference_bases().to_string());
+        self.alt.append_value(vcf_record.alternate_bases().to_string());
+        self.qual
+            .append_option(vcf_record.quality_score().map(f32::from));
+        self.filter
+            .append_option(vcf_record.filters().map(|f| f.to_string()));
+        self.info.append_value(vcf_record.info().to_string());
+        self.format.append_value(vcf_record.format().to_string());
+    }
+
+    fn finish(mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_from_iter(vec![
+            // spec
+            ("chrom", Arc::new(self.chrom.finish()) as ArrayRef),
+            ("pos", Arc::new(self.pos.finish()) as ArrayRef),
+            ("id", Arc::new(self.id.finish()) as ArrayRef),
+            ("ref", Arc::new(self.ref_.finish()) as ArrayRef),
+            ("alt", Arc::new(self.alt.finish()) as ArrayRef),
+            ("qual", Arc::new(self.qual.finish()) as ArrayRef),
+            ("filter", Arc::new(self.filter.finish()) as ArrayRef),
+            ("info", Arc::new(self.info.finish()) as ArrayRef),
+            ("format", Arc::new(self.format.finish()) as ArrayRef),
+        ])
+    }
+}

--- a/oxbow/src/lib.rs
+++ b/oxbow/src/lib.rs
@@ -26,3 +26,4 @@
 pub mod bam;
 mod batch_builder;
 pub mod vcf;
+pub mod bcf;

--- a/py-oxbow/Cargo.lock
+++ b/py-oxbow/Cargo.lock
@@ -866,6 +866,7 @@ name = "oxbow"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "byteorder",
  "noodles",
 ]
 

--- a/py-oxbow/Cargo.lock
+++ b/py-oxbow/Cargo.lock
@@ -651,6 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc3e1a97106b94104db416d3886594b2f4d7c49cdf90603b68ea4d71833b2b5"
 dependencies = [
  "noodles-bam",
+ "noodles-bcf",
  "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
@@ -673,6 +674,20 @@ dependencies = [
  "noodles-csi",
  "noodles-fasta",
  "noodles-sam",
+]
+
+[[package]]
+name = "noodles-bcf"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4238d1e714389fc4121efa3f5422e4810de051498733573fefc02ea8ad33231"
+dependencies = [
+ "byteorder",
+ "indexmap",
+ "noodles-bgzf",
+ "noodles-core",
+ "noodles-csi",
+ "noodles-vcf",
 ]
 
 [[package]]

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -3,6 +3,7 @@ use pyo3::types::PyBytes;
 
 use oxbow::bam::BamReader;
 use oxbow::vcf::VcfReader;
+use oxbow::bcf::BcfReader;
 
 #[pyfunction]
 fn read_bam(path: &str, region: Option<&str>) -> PyObject {
@@ -18,10 +19,18 @@ fn read_vcf(path: &str, region: Option<&str>) -> PyObject {
     Python::with_gil(|py| PyBytes::new(py, &ipc).into())
 }
 
+#[pyfunction]
+fn read_bcf(path: &str, region: Option<&str>) -> PyObject {
+    let mut reader = BcfReader::new(path).unwrap();
+    let ipc = reader.records_to_ipc(region).unwrap();
+    Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+}
+
 #[pymodule]
 #[pyo3(name = "oxbow")]
 fn py_oxbow(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_bam, m)?)?;
     m.add_function(wrap_pyfunction!(read_vcf, m)?)?;
+    m.add_function(wrap_pyfunction!(read_bcf, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
The `bcf::Reader` seems to choke on parsing the raw header on a test data set (early null termination of a Cstr), but the reader works for querying.

I reimplemented the header extraction to operator on a `bgzf::Reader` and it works, though it's not clear to me why it fails in the former case.
