### PR TITLE
Add vcf tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ docs/_build/
 # Pyenv
 .python-version
 
-data
+fixtures
 .Rbuildignore
 py-oxbow/notebooks/*.bam*
 .ipynb_checkpoints

--- a/oxbow/Cargo.toml
+++ b/oxbow/Cargo.toml
@@ -9,4 +9,4 @@ description = "Read specialized bioinformatic file formats as data frames in R, 
 [dependencies]
 arrow = "37.0.0"
 byteorder = "1.4.3"
-noodles = { version = "0.35.0", features = ["bam", "bcf", "bgzf", "core", "cram", "fasta", "fastq", "sam", "csi", "vcf", "tabix"] }
+noodles = { version = "0.45.0", features = ["bam", "bcf", "bgzf", "core", "cram", "fasta", "fastq", "sam", "csi", "vcf", "tabix"] }

--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -10,12 +10,15 @@ use noodles::{bam, bgzf, sam};
 use std::sync::Arc;
 
 use crate::batch_builder::{write_ipc, BatchBuilder};
+use crate::vpos;
 
 type BufferedReader = std::io::BufReader<std::fs::File>;
+
 
 /// A BAM reader.
 pub struct BamReader {
     reader: bam::IndexedReader<bgzf::Reader<BufferedReader>>,
+    unindexed_reader: bam::Reader<bgzf::Reader<std::fs::File>>,
     header: sam::Header,
 }
 
@@ -29,7 +32,8 @@ impl BamReader {
             .set_index(index)
             .build_from_reader(bufreader)?;
         let header = reader.read_header()?;
-        Ok(Self { reader, header })
+        let unindexed_reader = bam::reader::Builder::default().build_from_path(path).unwrap();
+        Ok(Self { reader, unindexed_reader, header })
     }
 
     /// Returns the records in the given region as Apache Arrow IPC.
@@ -56,6 +60,14 @@ impl BamReader {
             return write_ipc(query, batch_builder);
         }
         let records = self.reader.records(&self.header).map(|r| r.unwrap());
+        write_ipc(records, batch_builder)
+    }
+
+    pub fn records_to_ipc_from_vpos(&mut self, pos_lo: (u64, u16), pos_hi: (u64, u16)) -> Result<Vec<u8>, ArrowError> {
+        let vpos_lo = bgzf::VirtualPosition::try_from(pos_lo).unwrap();
+        let vpos_hi = bgzf::VirtualPosition::try_from(pos_hi).unwrap();
+        let batch_builder = BamBatchBuilder::new(1024, &self.header)?;
+        let records = vpos::BamRecords::new(&mut self.unindexed_reader, &self.header, vpos_lo, vpos_hi).map(|r| r.unwrap());
         write_ipc(records, batch_builder)
     }
 }
@@ -169,7 +181,7 @@ mod tests {
 
     fn read_record_batch(region: Option<&str>) -> RecordBatch {
         let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        dir.push("fixtures/sample.bam");
+        dir.push("../fixtures/sample.bam");
         let mut reader = BamReader::new(dir.to_str().unwrap()).unwrap();
         let ipc = reader.records_to_ipc(region).unwrap();
         let cursor = std::io::Cursor::new(ipc);

--- a/oxbow/src/lib.rs
+++ b/oxbow/src/lib.rs
@@ -26,7 +26,8 @@
 mod batch_builder;
 pub mod fasta;
 pub mod fastq;
+pub mod vpos;
 pub mod bam;
-pub mod cram;
+// pub mod cram;
 pub mod vcf;
 pub mod bcf;

--- a/oxbow/src/vcf.rs
+++ b/oxbow/src/vcf.rs
@@ -145,3 +145,40 @@ impl BatchBuilder for VcfBatchBuilder {
         ])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::ipc::reader::FileReader;
+    use arrow::record_batch::RecordBatch;
+
+    fn read_record_batch(region: Option<&str>) -> RecordBatch {
+        let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        dir.push("../fixtures/ALL.chrY.phase3_integrated_v1a.20130502.genotypes.vcf.gz");
+        let mut reader = VcfReader::new(dir.to_str().unwrap()).unwrap();
+        let ipc = reader.records_to_ipc(region).unwrap();
+        let cursor = std::io::Cursor::new(ipc);
+        let mut arrow_reader = FileReader::try_new(cursor, None).unwrap();
+        // make sure we have one batch
+        assert_eq!(arrow_reader.num_batches(), 1);
+        arrow_reader.next().unwrap().unwrap()
+    }
+
+    #[test]
+    fn test_read_all() {
+        let record_batch = read_record_batch(None);
+        assert_eq!(record_batch.num_rows(), 62042);
+    }
+
+    #[test]
+    fn test_region_full() {
+        let record_batch = read_record_batch(Some("Y"));
+        assert_eq!(record_batch.num_rows(), 62042);
+    }
+
+    #[test]
+    fn rest_region_partial() {
+        let record_batch = read_record_batch(Some("Y:8028497-17629059"));
+        assert_eq!(record_batch.num_rows(), 27947);
+    }
+}

--- a/oxbow/src/vpos.rs
+++ b/oxbow/src/vpos.rs
@@ -1,0 +1,303 @@
+use std::io::{self, Read, Seek, BufRead};
+use std::fs::File;
+use std::collections::HashSet;
+
+use noodles::bgzf;
+use noodles::bam::bai;
+// use noodles::cram::crai;
+use noodles::csi;
+use noodles::csi::index::ReferenceSequence;
+use noodles::tabix;
+use noodles::bam;
+use noodles::bcf;
+use noodles::sam;
+use noodles::vcf;
+
+const COMPRESSED_POSITION_SHIFT: u64 = 16;
+
+
+// Reads SAM records from a BAM file
+pub struct BamRecords<'a, R>
+where
+    R: Read + Seek,
+{
+    reader: &'a mut bam::Reader<bgzf::reader::Reader<R>>,
+    header: &'a sam::Header,
+    record: sam::alignment::Record,
+    vpos_lo: bgzf::VirtualPosition,
+    vpos_hi: bgzf::VirtualPosition,
+}
+
+impl<'a, R> BamRecords<'a, R>
+where
+    R: Read + Seek,
+{
+    pub fn new(
+        reader: &'a mut bam::Reader<bgzf::reader::Reader<R>>,
+        header: &'a sam::Header, 
+        vpos_lo: bgzf::VirtualPosition, 
+        vpos_hi: bgzf::VirtualPosition
+    ) -> Self {
+        let _ = reader.seek(vpos_lo);
+        Self {
+            reader,
+            header,
+            record: sam::alignment::Record::default(),
+            vpos_lo,
+            vpos_hi,
+        }
+    }
+}
+
+impl<'a, R> Iterator for BamRecords<'a, R>
+where
+    R: Read + Seek,
+{
+    type Item = io::Result<sam::alignment::Record>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.reader.virtual_position() >= self.vpos_hi {
+            return None;
+        }
+
+        match self.reader.read_record(self.header, &mut self.record) {
+            Ok(0) => None,
+            Ok(_) => Some(Ok(self.record.clone())),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+
+// Reads VCF Records from a VCF file
+pub struct VcfRecords<'r, 'h, R> {
+    reader: &'r mut vcf::Reader<bgzf::reader::Reader<R>>,
+    header: &'h vcf::Header,
+    record: vcf::record::Record,
+    vpos_lo: bgzf::VirtualPosition,
+    vpos_hi: bgzf::VirtualPosition,
+}
+
+impl<'r, 'h, R> VcfRecords<'r, 'h, R>
+where
+    R: Read + Seek,
+{
+    pub(crate) fn new(
+        reader: &'r mut vcf::Reader<bgzf::reader::Reader<R>>, 
+        header: &'h vcf::Header,
+        vpos_lo: bgzf::VirtualPosition,
+        vpos_hi: bgzf::VirtualPosition,
+    ) -> Self {
+        let _ = reader.seek(vpos_lo);
+        Self {
+            reader,
+            header,
+            record: vcf::Record::default(),
+            vpos_lo,
+            vpos_hi,
+        }
+    }
+}
+
+impl<'r, 'h, R> Iterator for VcfRecords<'r, 'h, R>
+where
+    R: Read + Seek,
+{
+    type Item = io::Result<vcf::Record>;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.reader.virtual_position() >= self.vpos_hi {
+            return None;
+        }    
+
+        match self.reader.read_record(self.header, &mut self.record) {
+            Ok(0) => None,
+            Ok(_) => Some(Ok(self.record.clone())),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+
+// Reads VCF Records from a BCF file
+pub struct BcfRecords<'r, 'h, R> {
+    reader: &'r mut bcf::Reader<bgzf::reader::Reader<R>>,
+    header: &'h vcf::Header,
+    record: vcf::Record,
+    vpos_lo: bgzf::VirtualPosition,
+    vpos_hi: bgzf::VirtualPosition,
+}
+
+impl<'r, 'h, R> BcfRecords<'r, 'h, R>
+where
+    R: Read + Seek,
+{
+    pub(crate) fn new(
+        reader: &'r mut bcf::Reader<bgzf::reader::Reader<R>>, 
+        header: &'h vcf::Header,
+        vpos_lo: bgzf::VirtualPosition,
+        vpos_hi: bgzf::VirtualPosition,
+    ) -> Self {
+        let _ = reader.seek(vpos_lo);
+        Self {
+            reader,
+            header,
+            record: vcf::Record::default(),
+            vpos_lo,
+            vpos_hi,
+        }
+    }
+}
+
+impl<'r, 'h, R> Iterator for BcfRecords<'r, 'h, R>
+where
+    R: Read + Seek,
+{
+    type Item = io::Result<vcf::Record>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.reader.virtual_position() >= self.vpos_hi {
+            return None;
+        }
+
+        match self.reader.read_record(self.header, &mut self.record) {
+            Ok(0) => None,
+            Ok(_) => Some(Ok(self.record.clone())),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+
+fn get_ref_last_position(rseq: &ReferenceSequence) -> bgzf::VirtualPosition {
+    let mut rend = rseq
+        .bins()
+        .values()
+        .map(|bin| {
+            bin.chunks()
+            .iter()
+            .map(|chunk| {chunk.end()})
+            .max()
+            .unwrap()
+        })
+        .max()
+        .unwrap();
+    rend
+}
+
+
+fn get_offsets_from_linear_index(rseq: &ReferenceSequence) -> Vec<(u64, u16)>{
+    let mut offsets: Vec<(u64, u16)> = Vec::new();
+    let mut rend = get_ref_last_position(&rseq);
+    for offset in rseq.linear_index() {
+        let a = offset.compressed();
+        let b = offset.uncompressed();
+        if a == 0 && b == 0 {
+            continue;
+        }
+        offsets.push((a, b));
+    }
+    offsets.push(
+        (rend.compressed(), rend.uncompressed())
+    );
+
+    // Remove duplicates and sort by compressed, then uncompressed
+    let mut offsets_uniq: HashSet<(u64, u16)> = offsets.drain(..).collect();
+    let mut offsets_uniq: Vec<(u64, u16)> = offsets_uniq.into_iter().collect();
+    offsets_uniq.sort_by_key(|&(a, b)| (a, b));
+    offsets_uniq
+}
+
+
+fn get_offsets_from_binning_index(rseq: &ReferenceSequence) -> Vec<(u64, u16)> {
+    let mut offsets: Vec<(u64, u16)> = Vec::new();
+    let mut rend = get_ref_last_position(&rseq);
+    for bin in rseq.bins().values() {
+        for chunk in bin.chunks() {
+            offsets.push(
+                (chunk.start().compressed(), chunk.start().uncompressed())
+            );
+            offsets.push(
+                (chunk.end().compressed(), chunk.end().uncompressed())
+            );
+        }
+    }
+    offsets.push(
+        (rend.compressed(), rend.uncompressed())
+    );
+
+    // Remove duplicates and sort by compressed, then uncompressed
+    let mut offsets_uniq: HashSet<(u64, u16)> = offsets.drain(..).collect();
+    let mut offsets_uniq: Vec<(u64, u16)> = offsets_uniq.into_iter().collect();
+    offsets_uniq.sort_by_key(|&(a, b)| (a, b));
+    offsets_uniq
+}
+
+
+fn consolidate_chunks(offsets: &Vec<(u64, u16)>, chunksize: u64) -> Vec<(u64, u16)> {
+    let mut consolidated = Vec::new();
+    let mut last_offset = 0;
+
+    consolidated.push(offsets[0]);
+    for &(offset, value) in &offsets[1..offsets.len() - 1]  {
+        if offset >= last_offset + chunksize {
+            consolidated.push((offset, value));
+            last_offset = offset;
+        }
+    }
+    consolidated.push(offsets[offsets.len() - 1]);
+
+    consolidated
+}
+
+
+fn partition_from_index(index: &csi::Index, chunksize: u64) -> Vec<(u64, u16)> {
+    let mut partition: Vec<(u64, u16)> = Vec::new();
+    for rseq in index.reference_sequences() {
+        if rseq.bins().is_empty() {
+            continue;
+        }
+        let offsets;
+        if rseq.linear_index().is_empty() {
+            offsets = get_offsets_from_binning_index(&rseq);
+        } else {
+            offsets = get_offsets_from_linear_index(&rseq);
+        }
+        let consolidated = consolidate_chunks(&offsets, chunksize);
+        partition.extend(consolidated);
+    }
+
+    // Remove duplicates and sort by compressed, then uncompressed
+    let mut partition: HashSet<(u64, u16)> = partition.drain(..).collect();
+    let mut partition: Vec<(u64, u16)> = partition.into_iter().collect();
+    partition.sort_by_key(|&(a, b)| (a, b));
+    partition
+}
+
+
+fn parse_index_file(path: &str) -> io::Result<csi::Index> {
+    if path.ends_with(".csi") {
+        let mut reader = File::open(path).map(csi::Reader::new)?;
+        return reader.read_index();
+    } else if path.ends_with(".tbi") {
+        let mut reader = File::open(path).map(tabix::Reader::new)?;
+        return reader.read_index();
+    } else if path.ends_with(".bai") {
+        let mut reader = File::open(path).map(bai::Reader::new)?;
+        reader.read_header()?;
+        return reader.read_index();
+    // } else if path.ends_with(".crai") {
+    //     let mut reader = File::open(path).map(crai::Reader::new)?;
+    //     reader.read_header()?;
+    //     return reader.read_index();
+    } else {
+        panic!("Index file must end with .csi, .tbi, .bai");
+    }
+}
+
+
+pub fn partition_from_index_file(path: &str, chunksize: u64) -> Vec<(u64, u16)> {
+    let index = parse_index_file(path).unwrap();
+    let partition = partition_from_index(&index, chunksize);
+    partition
+}

--- a/py-oxbow/Cargo.lock
+++ b/py-oxbow/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap",
+ "indexmap 1.9.3",
  "lexical-core",
  "num",
  "serde",
@@ -447,6 +447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "flatbuffers"
 version = "23.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +552,16 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -726,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.35.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc3e1a97106b94104db416d3886594b2f4d7c49cdf90603b68ea4d71833b2b5"
+checksum = "0ec5a0da9e505ec562008ecffa514f810bf131bf41de0c4a5c5d491b432b111f"
 dependencies = [
  "noodles-bam",
  "noodles-bcf",
@@ -745,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bam"
-version = "0.29.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3feb518ccf37d9146594564610dc199d382077874d40349823eb6a8387c0e91e"
+checksum = "bdeb844c20c1464b177bbc29221615b369533a59719c2c220ea0a1a9d069ad71"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -755,18 +777,17 @@ dependencies = [
  "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
- "noodles-fasta",
  "noodles-sam",
 ]
 
 [[package]]
 name = "noodles-bcf"
-version = "0.23.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4238d1e714389fc4121efa3f5422e4810de051498733573fefc02ea8ad33231"
+checksum = "dcf196464f5d391d2199d86f7d8965349c80143414a88676405859c16c75da3a"
 dependencies = [
  "byteorder",
- "indexmap",
+ "indexmap 2.0.0",
  "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
@@ -775,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bgzf"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bff155a5362c61d9b977648d874aa84aea88f7de032e43df908c7cd26b22b6d"
+checksum = "2985a96e0306878a47e223f1bc8b5c988de6ef1516797796e05349dac0a727b2"
 dependencies = [
  "byteorder",
  "bytes",
@@ -787,15 +808,15 @@ dependencies = [
 
 [[package]]
 name = "noodles-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f9ab09e13392e71797e7502109575d2aae5cb2002bd2304647f7746215c2fe"
+checksum = "94fbe3192fe33acacabaedd387657f39b0fc606f1996d546db0dfe14703b843a"
 
 [[package]]
 name = "noodles-cram"
-version = "0.26.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdb3e6c942d39a363acb6cff7eea82e2309920b841e8d6d163308953314acc3"
+checksum = "ad5b8ce88f8656ab8bc3ee263e7ec8523fd827613c385b192b09a916142dcfb6"
 dependencies = [
  "bitflags 2.2.1",
  "byteorder",
@@ -812,22 +833,22 @@ dependencies = [
 
 [[package]]
 name = "noodles-csi"
-version = "0.15.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc3cc919001db189463597c9347d4660bffa1a20e274b62682f7d0fa6943aa1"
+checksum = "55329e145d9b5ba58299e3f9e36512d143e19379f13c3480db7346bcfaadc679"
 dependencies = [
  "bit-vec",
  "byteorder",
- "indexmap",
+ "indexmap 2.0.0",
  "noodles-bgzf",
  "noodles-core",
 ]
 
 [[package]]
 name = "noodles-fasta"
-version = "0.20.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbcf02af0f440981cef550db3e078b588591e68abd791ab0767c599945b4b93"
+checksum = "9ebae7087afc126a9a5b96d381cf2d0ea334cbf3a57ba3773e94931d493922da"
 dependencies = [
  "bytes",
  "memchr",
@@ -843,25 +864,24 @@ checksum = "27c7d065ab7c0814ea9df05624a1be1410d2039b091213ac1cb5281866c3fdfb"
 
 [[package]]
 name = "noodles-sam"
-version = "0.26.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dfc20f345e8220c2c2471298a99567dcf5f19c50fe1a2c275d9fc2633a0f54"
+checksum = "d4bd534ba3782dfa9de672f6e39cea6c84fabc5a0fe97ec4351745565959e5f3"
 dependencies = [
  "bitflags 2.2.1",
- "indexmap",
+ "indexmap 2.0.0",
  "lexical-core",
  "memchr",
  "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
- "noodles-fasta",
 ]
 
 [[package]]
 name = "noodles-tabix"
-version = "0.18.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ffe974c2c1ccdea461194767df4c6dc8efd0d8422184b6f54eaaf7f8e9cfd9"
+checksum = "9056c1880629bbd50c7737c4d2cffcfb3610045a024776dad5cd606dd88feefc"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -872,11 +892,11 @@ dependencies = [
 
 [[package]]
 name = "noodles-vcf"
-version = "0.27.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4be4406c87ddefbec64fe0b398aeb41e926d8ac302438258e3b1cc6d5ccb5f4"
+checksum = "90ef8021080bdca5eb1328716ed418b0813deb950a244d2faf15e977a565048f"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "memchr",
  "nom",
  "noodles-bgzf",

--- a/py-oxbow/notebooks/vcf_test.ipynb
+++ b/py-oxbow/notebooks/vcf_test.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:25:36.359358488Z",
+     "start_time": "2023-07-28T21:25:36.343676929Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import oxbow as ox\n",
+    "import polars as pl\n",
+    "\n",
+    "vcf_path = \"../../fixtures/ALL.chrY.phase3_integrated_v1a.20130502.genotypes.vcf.gz\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[(0, 17799),\n (1011683, 45288),\n (2151905, 38743),\n (3152162, 51362),\n (4161902, 27635),\n (5226885, 50277),\n (5837934, 0)]"
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chunk_size = 1_000_000\n",
+    "partitions = ox.partition_from_index_file(vcf_path+\".tbi\", chunk_size)\n",
+    "partitions"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:25:36.364251095Z",
+     "start_time": "2023-07-28T21:25:36.344809900Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "(62042, 9)"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ipc = ox.read_vcf_vpos(vcf_path, partitions[0], partitions[-1])\n",
+    "df = pl.read_ipc(ipc)\n",
+    "df.shape"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:25:47.859944295Z",
+     "start_time": "2023-07-28T21:25:47.858574751Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "(62042, 9)"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_ipc = ox.read_vcf(vcf_path, \"Y\")\n",
+    "y_df = pl.read_ipc(y_ipc)\n",
+    "y_df.shape"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:25:59.636407396Z",
+     "start_time": "2023-07-28T21:25:47.861342030Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [],
+   "source": [
+    "# Check if the number of records for the entire range (via vpos) is equal to the total number of records when reading the whole vcf file\n",
+    "assert df.shape == y_df.shape"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:25:59.641174397Z",
+     "start_time": "2023-07-28T21:25:59.637062995Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [],
+   "source": [
+    "# Check if the cumulative length of the partitions equals the total number of records when reading the whole vcf file\n",
+    "cum_sum = 0\n",
+    "for p1, p2 in zip(partitions[:-1], partitions[1:]):\n",
+    "    p_ipc = ox.read_vcf_vpos(vcf_path, p1, p2)\n",
+    "    p_df = pl.read_ipc(p_ipc)\n",
+    "    cum_sum += p_df.shape[0]\n",
+    "assert cum_sum == df.shape[0]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:26:11.365620948Z",
+     "start_time": "2023-07-28T21:26:06.475957443Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (27_947, 9)\n",
+      "┌───────┬──────────┬─────┬─────┬───┬───────┬────────┬───────────────────────────────────┬────────┐\n",
+      "│ chrom ┆ pos      ┆ id  ┆ ref ┆ … ┆ qual  ┆ filter ┆ info                              ┆ format │\n",
+      "│ ---   ┆ ---      ┆ --- ┆ --- ┆   ┆ ---   ┆ ---    ┆ ---                               ┆ ---    │\n",
+      "│ cat   ┆ i32      ┆ str ┆ str ┆   ┆ f32   ┆ str    ┆ str                               ┆ str    │\n",
+      "╞═══════╪══════════╪═════╪═════╪═══╪═══════╪════════╪═══════════════════════════════════╪════════╡\n",
+      "│ Y     ┆ 8028497  ┆     ┆ G   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=G;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 8028609  ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 8028736  ┆     ┆ A   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=A;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 8028804  ┆     ┆ A   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=A;AC=61;AF=0.0494728;AN=1233;… ┆ GT     │\n",
+      "│ …     ┆ …        ┆ …   ┆ …   ┆ … ┆ …     ┆ …      ┆ …                                 ┆ …      │\n",
+      "│ Y     ┆ 17628718 ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 17628774 ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 17629007 ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 17629059 ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=4;AF=0.00324412;AN=1233;… ┆ GT     │\n",
+      "└───────┴──────────┴─────┴─────┴───┴───────┴────────┴───────────────────────────────────┴────────┘\n",
+      "(27947, 9)\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_ipc = ox.read_vcf_vpos(vcf_path, partitions[1], partitions[3])\n",
+    "test_df = pl.read_ipc(test_ipc)\n",
+    "print(test_df)\n",
+    "print(test_df.shape)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:26:17.195595864Z",
+     "start_time": "2023-07-28T21:26:11.362516537Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (10_897, 9)\n",
+      "┌───────┬──────────┬─────┬─────┬───┬───────┬────────┬───────────────────────────────────┬────────┐\n",
+      "│ chrom ┆ pos      ┆ id  ┆ ref ┆ … ┆ qual  ┆ filter ┆ info                              ┆ format │\n",
+      "│ ---   ┆ ---      ┆ --- ┆ --- ┆   ┆ ---   ┆ ---    ┆ ---                               ┆ ---    │\n",
+      "│ cat   ┆ i32      ┆ str ┆ str ┆   ┆ f32   ┆ str    ┆ str                               ┆ str    │\n",
+      "╞═══════╪══════════╪═════╪═════╪═══╪═══════╪════════╪═══════════════════════════════════╪════════╡\n",
+      "│ Y     ┆ 17629604 ┆     ┆ G   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=G;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 17629712 ┆     ┆ C   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=.;AC=2;AF=0.00162206;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 17629724 ┆     ┆ C   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=C;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 17629865 ┆     ┆ G   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=G;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ …     ┆ …        ┆ …   ┆ …   ┆ … ┆ …     ┆ …      ┆ …                                 ┆ …      │\n",
+      "│ Y     ┆ 21282669 ┆     ┆ C   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=C;AC=4;AF=0.00324412;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 21282748 ┆     ┆ C   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=C;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 21282774 ┆     ┆ G   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=G;AC=4;AF=0.00324412;AN=1233;… ┆ GT     │\n",
+      "│ Y     ┆ 21282782 ┆     ┆ C   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=C;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n",
+      "└───────┴──────────┴─────┴─────┴───┴───────┴────────┴───────────────────────────────────┴────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "test2_ipc = ox.read_vcf_vpos(vcf_path, partitions[3], partitions[4])\n",
+    "test2_df = pl.read_ipc(test2_ipc)\n",
+    "print(test2_df)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:26:19.279614900Z",
+     "start_time": "2023-07-28T21:26:17.197183182Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(27947, 9)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "shape: (27_947, 9)\n┌───────┬──────────┬─────┬─────┬───┬───────┬────────┬───────────────────────────────────┬────────┐\n│ chrom ┆ pos      ┆ id  ┆ ref ┆ … ┆ qual  ┆ filter ┆ info                              ┆ format │\n│ ---   ┆ ---      ┆ --- ┆ --- ┆   ┆ ---   ┆ ---    ┆ ---                               ┆ ---    │\n│ cat   ┆ i32      ┆ str ┆ str ┆   ┆ f32   ┆ str    ┆ str                               ┆ str    │\n╞═══════╪══════════╪═════╪═════╪═══╪═══════╪════════╪═══════════════════════════════════╪════════╡\n│ Y     ┆ 8028497  ┆     ┆ G   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=G;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n│ Y     ┆ 8028609  ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n│ Y     ┆ 8028736  ┆     ┆ A   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=A;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n│ Y     ┆ 8028804  ┆     ┆ A   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=A;AC=61;AF=0.0494728;AN=1233;… ┆ GT     │\n│ …     ┆ …        ┆ …   ┆ …   ┆ … ┆ …     ┆ …      ┆ …                                 ┆ …      │\n│ Y     ┆ 17628718 ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n│ Y     ┆ 17628774 ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n│ Y     ┆ 17629007 ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=1;AF=0.00081103;AN=1233;… ┆ GT     │\n│ Y     ┆ 17629059 ┆     ┆ T   ┆ … ┆ 100.0 ┆ PASS   ┆ AA=T;AC=4;AF=0.00324412;AN=1233;… ┆ GT     │\n└───────┴──────────┴─────┴─────┴───┴───────┴────────┴───────────────────────────────────┴────────┘",
+      "text/html": "<div><style>\n.dataframe > thead > tr > th,\n.dataframe > tbody > tr > td {\n  text-align: right;\n}\n</style>\n<small>shape: (27_947, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>chrom</th><th>pos</th><th>id</th><th>ref</th><th>alt</th><th>qual</th><th>filter</th><th>info</th><th>format</th></tr><tr><td>cat</td><td>i32</td><td>str</td><td>str</td><td>str</td><td>f32</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;Y&quot;</td><td>8028497</td><td>&quot;&quot;</td><td>&quot;G&quot;</td><td>&quot;T&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=G;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8028609</td><td>&quot;&quot;</td><td>&quot;T&quot;</td><td>&quot;C&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=T;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8028736</td><td>&quot;&quot;</td><td>&quot;A&quot;</td><td>&quot;G&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=A;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8028804</td><td>&quot;&quot;</td><td>&quot;A&quot;</td><td>&quot;AT&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=A;AC=61;AF=…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8028896</td><td>&quot;rs373433249&quot;</td><td>&quot;C&quot;</td><td>&quot;T&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=C;AC=35;AF=…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8028918</td><td>&quot;&quot;</td><td>&quot;T&quot;</td><td>&quot;A&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=T;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8029480</td><td>&quot;&quot;</td><td>&quot;G&quot;</td><td>&quot;A&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=G;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8029507</td><td>&quot;&quot;</td><td>&quot;A&quot;</td><td>&quot;G&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=A;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8029914</td><td>&quot;&quot;</td><td>&quot;G&quot;</td><td>&quot;T&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=G;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8030142</td><td>&quot;&quot;</td><td>&quot;C&quot;</td><td>&quot;T&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=C;AC=2;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8030599</td><td>&quot;&quot;</td><td>&quot;G&quot;</td><td>&quot;C&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=G;AC=9;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>8031478</td><td>&quot;&quot;</td><td>&quot;A&quot;</td><td>&quot;C&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=A;AC=3;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;Y&quot;</td><td>17627523</td><td>&quot;rs373863154&quot;</td><td>&quot;C&quot;</td><td>&quot;G&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=C;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17627898</td><td>&quot;&quot;</td><td>&quot;C&quot;</td><td>&quot;G&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=C;AC=3;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17627932</td><td>&quot;&quot;</td><td>&quot;T&quot;</td><td>&quot;C&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=T;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17628128</td><td>&quot;&quot;</td><td>&quot;T&quot;</td><td>&quot;C&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=T;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17628156</td><td>&quot;&quot;</td><td>&quot;A&quot;</td><td>&quot;G&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=.;AC=2;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17628282</td><td>&quot;&quot;</td><td>&quot;G&quot;</td><td>&quot;A&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=G;AC=4;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17628633</td><td>&quot;&quot;</td><td>&quot;C&quot;</td><td>&quot;A&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=C;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17628664</td><td>&quot;&quot;</td><td>&quot;C&quot;</td><td>&quot;G&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=C;AC=4;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17628718</td><td>&quot;&quot;</td><td>&quot;T&quot;</td><td>&quot;A&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=T;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17628774</td><td>&quot;&quot;</td><td>&quot;T&quot;</td><td>&quot;C&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=T;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17629007</td><td>&quot;&quot;</td><td>&quot;T&quot;</td><td>&quot;C&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=T;AC=1;AF=0…</td><td>&quot;GT&quot;</td></tr><tr><td>&quot;Y&quot;</td><td>17629059</td><td>&quot;&quot;</td><td>&quot;T&quot;</td><td>&quot;C&quot;</td><td>100.0</td><td>&quot;PASS&quot;</td><td>&quot;AA=T;AC=4;AF=0…</td><td>&quot;GT&quot;</td></tr></tbody></table></div>"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "foo_ipc = ox.read_vcf(vcf_path, \"Y:8028497-17629059\")\n",
+    "foo_df = pl.read_ipc(foo_ipc)\n",
+    "print(foo_df.shape)\n",
+    "foo_df"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-07-28T21:26:24.429722230Z",
+     "start_time": "2023-07-28T21:26:19.281207101Z"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -1,12 +1,23 @@
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+use pyo3::types::PyList;
 
 use oxbow::fasta::FastaReader;
 use oxbow::fastq::FastqReader;
 use oxbow::bam::BamReader;
-use oxbow::cram::CramReader;
+// use oxbow::cram::CramReader;
 use oxbow::vcf::VcfReader;
 use oxbow::bcf::BcfReader;
+
+use oxbow::vpos;
+use oxbow::vpos::{BamRecords, VcfRecords, BcfRecords};
+
+
+#[pyfunction]
+fn partition_from_index_file(path: &str, chunksize: u64) -> PyObject {
+    let voffsets = vpos::partition_from_index_file(path, chunksize);
+    Python::with_gil(|py| PyList::new(py, &voffsets).into())
+}
 
 #[pyfunction]
 fn read_fasta(path: &str, region: Option<&str>) -> PyObject {
@@ -30,16 +41,30 @@ fn read_bam(path: &str, region: Option<&str>) -> PyObject {
 }
 
 #[pyfunction]
-fn read_cram(path: &str, fasta_path: &str, region: Option<&str>) -> PyObject {
-    let mut reader = CramReader::new(path, fasta_path).unwrap();
-    let ipc = reader.records_to_ipc(region).unwrap();
+fn read_bam_vpos(path: &str, pos_lo: (u64, u16), pos_hi: (u64, u16)) -> PyObject {
+    let mut reader = BamReader::new(path).unwrap();
+    let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi).unwrap();
     Python::with_gil(|py| PyBytes::new(py, &ipc).into())
 }
+
+// #[pyfunction]
+// fn read_cram(path: &str, fasta_path: &str, region: Option<&str>) -> PyObject {
+//     let mut reader = CramReader::new(path, fasta_path).unwrap();
+//     let ipc = reader.records_to_ipc(region).unwrap();
+//     Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+// }
 
 #[pyfunction]
 fn read_vcf(path: &str, region: Option<&str>) -> PyObject {
     let mut reader = VcfReader::new(path).unwrap();
     let ipc = reader.records_to_ipc(region).unwrap();
+    Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+}
+
+#[pyfunction]
+fn read_vcf_vpos(path: &str, pos_lo: (u64, u16), pos_hi: (u64, u16)) -> PyObject {
+    let mut reader = VcfReader::new(path).unwrap();
+    let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi).unwrap();
     Python::with_gil(|py| PyBytes::new(py, &ipc).into())
 }
 
@@ -50,14 +75,25 @@ fn read_bcf(path: &str, region: Option<&str>) -> PyObject {
     Python::with_gil(|py| PyBytes::new(py, &ipc).into())
 }
 
+#[pyfunction]
+fn read_bcf_vpos(path: &str, pos_lo: (u64, u16), pos_hi: (u64, u16)) -> PyObject {
+    let mut reader = BcfReader::new(path).unwrap();
+    let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi).unwrap();
+    Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+}
+
 #[pymodule]
 #[pyo3(name = "oxbow")]
 fn py_oxbow(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_fasta, m)?)?;
     m.add_function(wrap_pyfunction!(read_fastq, m)?)?;
+    m.add_function(wrap_pyfunction!(partition_from_index_file, m)?)?;
     m.add_function(wrap_pyfunction!(read_bam, m)?)?;
-    m.add_function(wrap_pyfunction!(read_cram, m)?)?;
+    m.add_function(wrap_pyfunction!(read_bam_vpos, m)?)?;
+    // m.add_function(wrap_pyfunction!(read_cram, m)?)?;
     m.add_function(wrap_pyfunction!(read_vcf, m)?)?;
+    m.add_function(wrap_pyfunction!(read_vcf_vpos, m)?)?;
     m.add_function(wrap_pyfunction!(read_bcf, m)?)?;
+    m.add_function(wrap_pyfunction!(read_bcf_vpos, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
Follows #17 
The vcf tests mirror the bam record batch tests. They use the full vcf file (must be downloaded from S3) from the root fixtures directory. It would be ideal to replace it with a smaller synthetic vcf so that the tests run faster.