### PR TITLE
Add vcf tests

### DIFF
--- a/oxbow/src/vcf.rs
+++ b/oxbow/src/vcf.rs
@@ -213,37 +213,37 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use arrow::ipc::reader::FileReader;
-    use arrow::record_batch::RecordBatch;
+    // use super::*;
+    // use arrow::ipc::reader::FileReader;
+    // use arrow::record_batch::RecordBatch;
 
-    fn read_record_batch(region: Option<&str>) -> RecordBatch {
-        let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        dir.push("../fixtures/ALL.chrY.phase3_integrated_v1a.20130502.genotypes.vcf.gz");
-        let mut reader = VcfReader::new(dir.to_str().unwrap()).unwrap();
-        let ipc = reader.records_to_ipc(region).unwrap();
-        let cursor = std::io::Cursor::new(ipc);
-        let mut arrow_reader = FileReader::try_new(cursor, None).unwrap();
-        // make sure we have one batch
-        assert_eq!(arrow_reader.num_batches(), 1);
-        arrow_reader.next().unwrap().unwrap()
-    }
+    // fn read_record_batch(region: Option<&str>) -> RecordBatch {
+    //     let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    //     dir.push("../fixtures/ALL.chrY.phase3_integrated_v1a.20130502.genotypes.vcf.gz");
+    //     let mut reader = VcfReader::new(dir.to_str().unwrap()).unwrap();
+    //     let ipc = reader.records_to_ipc(region).unwrap();
+    //     let cursor = std::io::Cursor::new(ipc);
+    //     let mut arrow_reader = FileReader::try_new(cursor, None).unwrap();
+    //     // make sure we have one batch
+    //     assert_eq!(arrow_reader.num_batches(), 1);
+    //     arrow_reader.next().unwrap().unwrap()
+    // }
 
-    #[test]
-    fn test_read_all() {
-        let record_batch = read_record_batch(None);
-        assert_eq!(record_batch.num_rows(), 62042);
-    }
+    // #[test]
+    // fn test_read_all() {
+    //     let record_batch = read_record_batch(None);
+    //     assert_eq!(record_batch.num_rows(), 62042);
+    // }
 
-    #[test]
-    fn test_region_full() {
-        let record_batch = read_record_batch(Some("Y"));
-        assert_eq!(record_batch.num_rows(), 62042);
-    }
+    // #[test]
+    // fn test_region_full() {
+    //     let record_batch = read_record_batch(Some("Y"));
+    //     assert_eq!(record_batch.num_rows(), 62042);
+    // }
 
-    #[test]
-    fn rest_region_partial() {
-        let record_batch = read_record_batch(Some("Y:8028497-17629059"));
-        assert_eq!(record_batch.num_rows(), 27947);
-    }
+    // #[test]
+    // fn rest_region_partial() {
+    //     let record_batch = read_record_batch(Some("Y:8028497-17629059"));
+    //     assert_eq!(record_batch.num_rows(), 27947);
+    // }
 }

--- a/oxbow/src/vcf.rs
+++ b/oxbow/src/vcf.rs
@@ -210,3 +210,40 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::ipc::reader::FileReader;
+    use arrow::record_batch::RecordBatch;
+
+    fn read_record_batch(region: Option<&str>) -> RecordBatch {
+        let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        dir.push("../fixtures/ALL.chrY.phase3_integrated_v1a.20130502.genotypes.vcf.gz");
+        let mut reader = VcfReader::new(dir.to_str().unwrap()).unwrap();
+        let ipc = reader.records_to_ipc(region).unwrap();
+        let cursor = std::io::Cursor::new(ipc);
+        let mut arrow_reader = FileReader::try_new(cursor, None).unwrap();
+        // make sure we have one batch
+        assert_eq!(arrow_reader.num_batches(), 1);
+        arrow_reader.next().unwrap().unwrap()
+    }
+
+    #[test]
+    fn test_read_all() {
+        let record_batch = read_record_batch(None);
+        assert_eq!(record_batch.num_rows(), 62042);
+    }
+
+    #[test]
+    fn test_region_full() {
+        let record_batch = read_record_batch(Some("Y"));
+        assert_eq!(record_batch.num_rows(), 62042);
+    }
+
+    #[test]
+    fn rest_region_partial() {
+        let record_batch = read_record_batch(Some("Y:8028497-17629059"));
+        assert_eq!(record_batch.num_rows(), 27947);
+    }
+}


### PR DESCRIPTION
Adds tests for vcf parsing using the vcf fixture data.

Note that vcf parsing is currently very slow. Merging this PR will increase `cargo test` times by 2-4 minutes when all of the other tests complete within a minute locally.

It may not be worth merging this PR now, although the vcf tests did pass locally.

Closing #18 in favor of this PR.

**Checklist**

- [x] Ran `cargo fmt`
- [x] Added tests
