### PR TITLE
Get tag values from bam file

### DIFF
--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -89,7 +89,7 @@ impl<R: Read + Seek> BamReader<R> {
 
     /// Returns the records in the given region as Apache Arrow IPC.
     ///
-    /// If the region is `None`, all records are returned. The second paramter to 
+    /// If the region is `None`, all records are returned. The second paramter to
     /// `records_to_ipc` is a set of tags to include in the output. If it is `None`,
     /// all tags are included. If it is `Some`, only the tags in the set are included.
     ///

--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -89,7 +89,9 @@ impl<R: Read + Seek> BamReader<R> {
 
     /// Returns the records in the given region as Apache Arrow IPC.
     ///
-    /// If the region is `None`, all records are returned.
+    /// If the region is `None`, all records are returned. The second paramter to 
+    /// `records_to_ipc` is a set of tags to include in the output. If it is `None`,
+    /// all tags are included. If it is `Some`, only the tags in the set are included.
     ///
     /// # Examples
     ///
@@ -97,7 +99,7 @@ impl<R: Read + Seek> BamReader<R> {
     /// use oxbow::bam::BamReader;
     ///
     /// let mut reader = BamReader::new_from_path("sample.bam").unwrap();
-    /// let ipc = reader.records_to_ipc(Some("sq0:1-1000")).unwrap();
+    /// let ipc = reader.records_to_ipc(Some("sq0:1-1000"), None).unwrap();
     /// ```
     pub fn records_to_ipc(
         &mut self,

--- a/oxbow/src/bigbed.rs
+++ b/oxbow/src/bigbed.rs
@@ -255,7 +255,7 @@ impl BatchBuilder for BigBedBatchBuilder {
                     std::iter::zip(columns.iter_mut(), record.rest.split_whitespace())
                 {
                     let Some((_, builder)) = builder else {
-                        continue
+                        continue;
                     };
                     match builder {
                         Column::Int(builder) => {

--- a/oxbow/src/bigbed.rs
+++ b/oxbow/src/bigbed.rs
@@ -254,7 +254,9 @@ impl BatchBuilder for BigBedBatchBuilder {
                 for (builder, col) in
                     std::iter::zip(columns.iter_mut(), record.rest.split_whitespace())
                 {
-                    let Some((_, builder)) = builder else { continue };
+                    let Some((_, builder)) = builder else {
+                        continue
+                    };
                     match builder {
                         Column::Int(builder) => {
                             let value: i32 = col.replace(",", "").parse().unwrap();

--- a/oxbow/src/lib.rs
+++ b/oxbow/src/lib.rs
@@ -8,7 +8,7 @@
 //! use oxbow::bam::BamReader;
 //!
 //! let mut reader = BamReader::new_from_path("sample.bam").unwrap();
-//! let ipc = reader.records_to_ipc(None).unwrap();
+//! let ipc = reader.records_to_ipc(None, None).unwrap();
 //! ```
 //!
 //! ## Query records
@@ -19,7 +19,7 @@
 //! use oxbow::bam::BamReader;
 //!
 //! let mut reader = BamReader::new_from_path("sample.bam").unwrap();
-//! let ipc = reader.records_to_ipc(Some("chr1:1-100000")).unwrap();
+//! let ipc = reader.records_to_ipc(Some("chr1:1-100000"), None).unwrap();
 //! ```
 //!
 

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -49,11 +49,12 @@ fn read_bam(
     path_or_file_like: PyObject,
     region: Option<&str>,
     index: Option<PyObject>,
+    tags: Option<HashSet<&str>>
 ) -> PyObject {
     if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
         // If it's a string, treat it as a path
         let mut reader = BamReader::new_from_path(string_ref.to_str().unwrap()).unwrap();
-        let ipc = reader.records_to_ipc(region).unwrap();
+        let ipc = reader.records_to_ipc(region, tags).unwrap();
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     } else {
         // Otherwise, treat it as file-like
@@ -67,7 +68,7 @@ fn read_bam(
         };
         let index = bam::index_from_reader(index_file_like).unwrap();
         let mut reader = BamReader::new(file_like, index).unwrap();
-        let ipc = reader.records_to_ipc(region).unwrap();
+        let ipc = reader.records_to_ipc(region, tags).unwrap();
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     }
 }
@@ -79,11 +80,12 @@ fn read_bam_vpos(
     pos_lo: (u64, u16),
     pos_hi: (u64, u16),
     index: Option<PyObject>,
+    tags: Option<HashSet<&str>>
 ) -> PyObject {
     if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
         // If it's a string, treat it as a path
         let mut reader = BamReader::new_from_path(string_ref.to_str().unwrap()).unwrap();
-        let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi).unwrap();
+        let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi, tags).unwrap();
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     } else {
         // Otherwise, treat it as file-like
@@ -97,7 +99,7 @@ fn read_bam_vpos(
         };
         let index = bam::index_from_reader(index_file_like).unwrap();
         let mut reader = BamReader::new(file_like, index).unwrap();
-        let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi).unwrap();
+        let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi, tags).unwrap();
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     }
 }

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -49,7 +49,7 @@ fn read_bam(
     path_or_file_like: PyObject,
     region: Option<&str>,
     index: Option<PyObject>,
-    tags: Option<HashSet<&str>>
+    tags: Option<HashSet<&str>>,
 ) -> PyObject {
     if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
         // If it's a string, treat it as a path
@@ -80,12 +80,14 @@ fn read_bam_vpos(
     pos_lo: (u64, u16),
     pos_hi: (u64, u16),
     index: Option<PyObject>,
-    tags: Option<HashSet<&str>>
+    tags: Option<HashSet<&str>>,
 ) -> PyObject {
     if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
         // If it's a string, treat it as a path
         let mut reader = BamReader::new_from_path(string_ref.to_str().unwrap()).unwrap();
-        let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi, tags).unwrap();
+        let ipc = reader
+            .records_to_ipc_from_vpos(pos_lo, pos_hi, tags)
+            .unwrap();
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     } else {
         // Otherwise, treat it as file-like
@@ -99,7 +101,9 @@ fn read_bam_vpos(
         };
         let index = bam::index_from_reader(index_file_like).unwrap();
         let mut reader = BamReader::new(file_like, index).unwrap();
-        let ipc = reader.records_to_ipc_from_vpos(pos_lo, pos_hi, tags).unwrap();
+        let ipc = reader
+            .records_to_ipc_from_vpos(pos_lo, pos_hi, tags)
+            .unwrap();
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     }
 }
@@ -268,7 +272,12 @@ fn read_bigwig(
 }
 
 #[pyfunction]
-fn read_bigbed(py: Python, path_or_file_like: PyObject, region: Option<&str>, fields: Option<HashSet<&str>>) -> PyObject {
+fn read_bigbed(
+    py: Python,
+    path_or_file_like: PyObject,
+    region: Option<&str>,
+    fields: Option<HashSet<&str>>,
+) -> PyObject {
     if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
         // If it's a string, treat it as a path
         let mut reader = BigBedReader::new_from_path(string_ref.to_str().unwrap()).unwrap();


### PR DESCRIPTION
Rudimentary support for retrieving tags from BAM files. To use, instantiate a `BamReader` with a list of tags to be returned:

```
let reader = BamReader::new_from_path("my/path", vec!["MD", "NM"])
reader.read_from_ipc()
```

The returned structure contains extra columns for each of the columns specified.

This PR has a number of limitations:

1. There's no way to say "return all tags", without specifying all known tags. Maybe making the tags parameter optional and returning all tags when that's the case?

2. It currently converts all tags to strings when they are returned. This is because I couldn't figure out how to select the appropriate `arrow:array` function to use to accommodate the multitude of types that could be in `noodles::sam::record::data::field::Value`.

There's likely other shortcomings but these are the immediately obvious ones. Any feedback or help with either of these points would be greatly appreciated.

