### PR TITLE
Create GFF and GTF readers

### DIFF
--- a/fixtures/example.gff
+++ b/fixtures/example.gff
@@ -1,0 +1,7 @@
+##gff-version 3
+ctg123	.	mRNA	1300	9000	.	+	.	ID=mrna0001;Name=sonichedgehog
+ctg123	.	exon	1300	1500	.	+	.	ID=exon00001;Parent=mrna0001
+ctg123	.	exon	1050	1500	.	+	.	ID=exon00002;Parent=mrna0001
+ctg123	.	exon	3000	3902	.	+	.	ID=exon00003;Parent=mrna0001
+ctg123	.	exon	5000	5500	.	+	.	ID=exon00004;Parent=mrna0001
+ctg123	.	exon	7000	9000	.	+	.	ID=exon00005;Parent=mrna0001

--- a/fixtures/example.gtf
+++ b/fixtures/example.gtf
@@ -1,0 +1,2 @@
+1	transcribed_unprocessed_pseudogene	gene	11869	14409	.	+	.	gene_id "ENSG00000223972"; gene_name "DDX11L1"; gene_source "havana"; gene_biotype "transcribed_unprocessed_pseudogene";
+1	processed_transcript	transcript	11869	14409	.	+	.	gene_id "ENSG00000223972"; transcript_id "ENST00000456328"; gene_name "DDX11L1"; gene_source "havana"; gene_biotype "transcribed_unprocessed_pseudogene"; transcript_name "DDX11L1-002"; transcript_source "havana";

--- a/oxbow/Cargo.lock
+++ b/oxbow/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "noodles-csi",
  "noodles-fasta",
  "noodles-fastq",
+ "noodles-gff",
  "noodles-sam",
  "noodles-tabix",
  "noodles-vcf",
@@ -879,6 +880,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1763486d2d1a1e39a86676a47aa05728c75f73f0f883415e36439711ead2641"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "noodles-gff"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29cd6131bf39317a7b222eab0e99f3a14559e02a2a8c22e6160f66d17a513b74"
+dependencies = [
+ "indexmap 2.0.0",
+ "noodles-bgzf",
+ "noodles-core",
+ "noodles-csi",
+ "percent-encoding",
 ]
 
 [[package]]

--- a/oxbow/Cargo.lock
+++ b/oxbow/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "noodles-fasta",
  "noodles-fastq",
  "noodles-gff",
+ "noodles-gtf",
  "noodles-sam",
  "noodles-tabix",
  "noodles-vcf",
@@ -893,6 +894,17 @@ dependencies = [
  "noodles-core",
  "noodles-csi",
  "percent-encoding",
+]
+
+[[package]]
+name = "noodles-gtf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "096367bb382b244da2dc087a9628daecae299a5641f6572f28627f2001187465"
+dependencies = [
+ "noodles-bgzf",
+ "noodles-core",
+ "noodles-csi",
 ]
 
 [[package]]

--- a/oxbow/Cargo.toml
+++ b/oxbow/Cargo.toml
@@ -9,5 +9,5 @@ description = "Read specialized bioinformatic file formats as data frames in R, 
 [dependencies]
 arrow = "37.0.0"
 byteorder = "1.4.3"
-noodles = { version = "0.45.0", features = ["bam", "bcf", "bgzf", "core", "cram", "fasta", "fastq", "gff", "sam", "csi", "vcf", "tabix"] }
+noodles = { version = "0.45.0", features = ["bam", "bcf", "bgzf", "core", "cram", "fasta", "fastq", "gff", "gtf", "sam", "csi", "vcf", "tabix"] }
 bigtools = { version = "0.2.5", default-features = false, features = ["read"] }

--- a/oxbow/Cargo.toml
+++ b/oxbow/Cargo.toml
@@ -9,5 +9,5 @@ description = "Read specialized bioinformatic file formats as data frames in R, 
 [dependencies]
 arrow = "37.0.0"
 byteorder = "1.4.3"
-noodles = { version = "0.45.0", features = ["bam", "bcf", "bgzf", "core", "cram", "fasta", "fastq", "sam", "csi", "vcf", "tabix"] }
+noodles = { version = "0.45.0", features = ["bam", "bcf", "bgzf", "core", "cram", "fasta", "fastq", "gff", "sam", "csi", "vcf", "tabix"] }
 bigtools = { version = "0.2.5", default-features = false, features = ["read"] }

--- a/oxbow/src/bigbed.rs
+++ b/oxbow/src/bigbed.rs
@@ -254,7 +254,9 @@ impl BatchBuilder for BigBedBatchBuilder {
                 for (builder, col) in
                     std::iter::zip(columns.iter_mut(), record.rest.split_whitespace())
                 {
-                    let Some((_, builder)) = builder else { continue };
+                    let Some((_, builder)) = builder else {
+                        continue;
+                    };
                     match builder {
                         Column::Int(builder) => {
                             let value: i32 = col.replace(",", "").parse().unwrap();

--- a/oxbow/src/gff.rs
+++ b/oxbow/src/gff.rs
@@ -1,0 +1,147 @@
+use std::fs::File;
+use std::io::{BufReader, Read, Seek};
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Float32Builder, GenericStringBuilder, Int32Builder};
+use arrow::error::ArrowError;
+use arrow::record_batch::RecordBatch;
+use noodles::gff;
+
+use crate::batch_builder::{write_ipc_err, BatchBuilder};
+
+/// A GFF reader.
+pub struct GffReader<R> {
+    reader: gff::Reader<BufReader<R>>,
+}
+
+impl GffReader<BufReader<File>> {
+    /// Creates a GFF reader from a given file path.
+    pub fn new_from_path(path: &str) -> std::io::Result<Self> {
+        let reader = File::open(path)
+            .map(BufReader::new)
+            .map(BufReader::new)
+            .map(gff::Reader::new)?;
+        Ok(Self { reader })
+    }
+}
+
+impl<R: Read + Seek> GffReader<R> {
+    /// Creates a GFF Reader.
+    pub fn new(read: R) -> std::io::Result<Self> {
+        let reader = gff::Reader::new(BufReader::new(read));
+        Ok(Self { reader })
+    }
+
+    /// Returns the records in the given region as Apache Arrow IPC.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use oxbow::gff::GffReader;
+    ///
+    /// let mut reader = GffReader::new_from_path("sample.gff").unwrap();
+    /// let ipc = reader.records_to_ipc().unwrap();
+    /// ```
+    pub fn records_to_ipc(&mut self) -> Result<Vec<u8>, ArrowError> {
+        let batch_builder = GffBatchBuilder::new(1024)?;
+        let records = self
+            .reader
+            .records()
+            .map(|i| i.map_err(|e| ArrowError::ExternalError(e.into())));
+        return write_ipc_err(records, batch_builder);
+    }
+}
+
+struct GffBatchBuilder {
+    reference_sequence_name: GenericStringBuilder<i32>,
+    source: GenericStringBuilder<i32>,
+    ty: GenericStringBuilder<i32>,
+    start: Int32Builder,
+    end: Int32Builder,
+    score: Float32Builder,
+    strand: GenericStringBuilder<i32>,
+    phase: GenericStringBuilder<i32>,
+    attributes: GenericStringBuilder<i32>,
+}
+
+impl GffBatchBuilder {
+    pub fn new(capacity: usize) -> Result<Self, ArrowError> {
+        Ok(Self {
+            reference_sequence_name: GenericStringBuilder::<i32>::new(),
+            source: GenericStringBuilder::<i32>::new(),
+            ty: GenericStringBuilder::<i32>::new(),
+            start: Int32Builder::with_capacity(capacity),
+            end: Int32Builder::with_capacity(capacity),
+            score: Float32Builder::new(),
+            strand: GenericStringBuilder::<i32>::new(),
+            phase: GenericStringBuilder::<i32>::new(),
+            attributes: GenericStringBuilder::<i32>::new(),
+        })
+    }
+}
+
+impl BatchBuilder for GffBatchBuilder {
+    type Record<'a> = &'a gff::record::Record;
+
+    fn push(&mut self, record: Self::Record<'_>) {
+        self.reference_sequence_name
+            .append_value(record.reference_sequence_name().to_string());
+        self.source.append_value(record.source().to_string());
+        self.ty.append_value(record.ty().to_string());
+        self.start.append_value(usize::from(record.start()) as i32);
+        self.end.append_value(usize::from(record.end()) as i32);
+        match record.score() {
+            Some(score) => self.score.append_value(score),
+            None => self.score.append_null(),
+        }
+        self.strand.append_value(record.strand().to_string());
+        match record.phase() {
+            Some(phase) => self.phase.append_value(phase),
+            None => self.phase.append_null(),
+        }
+        self.attributes
+            .append_value(record.attributes().to_string());
+    }
+
+    fn finish(mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_from_iter(vec![
+            (
+                "seqid",
+                Arc::new(self.reference_sequence_name.finish()) as ArrayRef,
+            ),
+            ("source", Arc::new(self.source.finish()) as ArrayRef),
+            ("type", Arc::new(self.ty.finish()) as ArrayRef),
+            ("start", Arc::new(self.start.finish()) as ArrayRef),
+            ("end", Arc::new(self.end.finish()) as ArrayRef),
+            ("score", Arc::new(self.score.finish()) as ArrayRef),
+            ("strand", Arc::new(self.strand.finish()) as ArrayRef),
+            ("phase", Arc::new(self.phase.finish()) as ArrayRef),
+            ("attributes", Arc::new(self.attributes.finish()) as ArrayRef),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::ipc::reader::FileReader;
+    use arrow::record_batch::RecordBatch;
+
+    fn read_record_batch() -> RecordBatch {
+        let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        dir.push("../fixtures/example.gff");
+        let mut reader = GffReader::new_from_path(dir.to_str().unwrap()).unwrap();
+        let ipc = reader.records_to_ipc().unwrap();
+        let cursor = std::io::Cursor::new(ipc);
+        let mut arrow_reader = FileReader::try_new(cursor, None).unwrap();
+        // make sure we have one batch
+        assert_eq!(arrow_reader.num_batches(), 1);
+        arrow_reader.next().unwrap().unwrap()
+    }
+
+    #[test]
+    fn test_read_all() {
+        let record_batch = read_record_batch();
+        assert_eq!(record_batch.num_rows(), 6);
+    }
+}

--- a/oxbow/src/gtf.rs
+++ b/oxbow/src/gtf.rs
@@ -1,0 +1,150 @@
+use std::fs::File;
+use std::io::{BufReader, Read, Seek};
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Float32Builder, GenericStringBuilder, Int32Builder};
+use arrow::error::ArrowError;
+use arrow::record_batch::RecordBatch;
+use noodles::gtf;
+
+use crate::batch_builder::{write_ipc_err, BatchBuilder};
+
+/// A GTF reader.
+pub struct GtfReader<R> {
+    reader: gtf::Reader<BufReader<R>>,
+}
+
+impl GtfReader<BufReader<File>> {
+    /// Creates a GTF reader from a given file path.
+    pub fn new_from_path(path: &str) -> std::io::Result<Self> {
+        let reader = File::open(path)
+            .map(BufReader::new)
+            .map(BufReader::new)
+            .map(gtf::Reader::new)?;
+        Ok(Self { reader })
+    }
+}
+
+impl<R: Read + Seek> GtfReader<R> {
+    /// Creates a GTF Reader.
+    pub fn new(read: R) -> std::io::Result<Self> {
+        let reader = gtf::Reader::new(BufReader::new(read));
+        Ok(Self { reader })
+    }
+
+    /// Returns the records in the given region as Apache Arrow IPC.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use oxbow::gtf::GtfReader;
+    ///
+    /// let mut reader = GtfReader::new_from_path("sample.gtf").unwrap();
+    /// let ipc = reader.records_to_ipc().unwrap();
+    /// ```
+    pub fn records_to_ipc(&mut self) -> Result<Vec<u8>, ArrowError> {
+        let batch_builder = GtfBatchBuilder::new(1024)?;
+        let records = self
+            .reader
+            .records()
+            .map(|i| i.map_err(|e| ArrowError::ExternalError(e.into())));
+        return write_ipc_err(records, batch_builder);
+    }
+}
+
+struct GtfBatchBuilder {
+    reference_sequence_name: GenericStringBuilder<i32>,
+    source: GenericStringBuilder<i32>,
+    ty: GenericStringBuilder<i32>,
+    start: Int32Builder,
+    end: Int32Builder,
+    score: Float32Builder,
+    strand: GenericStringBuilder<i32>,
+    frame: GenericStringBuilder<i32>,
+    attributes: GenericStringBuilder<i32>,
+}
+
+impl GtfBatchBuilder {
+    pub fn new(capacity: usize) -> Result<Self, ArrowError> {
+        Ok(Self {
+            reference_sequence_name: GenericStringBuilder::<i32>::new(),
+            source: GenericStringBuilder::<i32>::new(),
+            ty: GenericStringBuilder::<i32>::new(),
+            start: Int32Builder::with_capacity(capacity),
+            end: Int32Builder::with_capacity(capacity),
+            score: Float32Builder::new(),
+            strand: GenericStringBuilder::<i32>::new(),
+            frame: GenericStringBuilder::<i32>::new(),
+            attributes: GenericStringBuilder::<i32>::new(),
+        })
+    }
+}
+
+impl BatchBuilder for GtfBatchBuilder {
+    type Record<'a> = &'a gtf::record::Record;
+
+    fn push(&mut self, record: Self::Record<'_>) {
+        self.reference_sequence_name
+            .append_value(record.reference_sequence_name().to_string());
+        self.source.append_value(record.source().to_string());
+        self.ty.append_value(record.ty().to_string());
+        self.start.append_value(usize::from(record.start()) as i32);
+        self.end.append_value(usize::from(record.end()) as i32);
+        match record.score() {
+            Some(score) => self.score.append_value(score),
+            None => self.score.append_null(),
+        }
+        match record.strand() {
+            Some(strand) => self.strand.append_value(strand.to_string()),
+            None => self.strand.append_null(),
+        }
+        match record.frame() {
+            Some(frame) => self.frame.append_value(frame.to_string()),
+            None => self.frame.append_null(),
+        }
+        self.attributes
+            .append_value(record.attributes().to_string());
+    }
+
+    fn finish(mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_from_iter(vec![
+            (
+                "seqid",
+                Arc::new(self.reference_sequence_name.finish()) as ArrayRef,
+            ),
+            ("source", Arc::new(self.source.finish()) as ArrayRef),
+            ("type", Arc::new(self.ty.finish()) as ArrayRef),
+            ("start", Arc::new(self.start.finish()) as ArrayRef),
+            ("end", Arc::new(self.end.finish()) as ArrayRef),
+            ("score", Arc::new(self.score.finish()) as ArrayRef),
+            ("strand", Arc::new(self.strand.finish()) as ArrayRef),
+            ("frame", Arc::new(self.frame.finish()) as ArrayRef),
+            ("attributes", Arc::new(self.attributes.finish()) as ArrayRef),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::ipc::reader::FileReader;
+    use arrow::record_batch::RecordBatch;
+
+    fn read_record_batch() -> RecordBatch {
+        let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        dir.push("../fixtures/example.gtf");
+        let mut reader = GtfReader::new_from_path(dir.to_str().unwrap()).unwrap();
+        let ipc = reader.records_to_ipc().unwrap();
+        let cursor = std::io::Cursor::new(ipc);
+        let mut arrow_reader = FileReader::try_new(cursor, None).unwrap();
+        // make sure we have one batch
+        assert_eq!(arrow_reader.num_batches(), 1);
+        arrow_reader.next().unwrap().unwrap()
+    }
+
+    #[test]
+    fn test_read_all() {
+        let record_batch = read_record_batch();
+        assert_eq!(record_batch.num_rows(), 2);
+    }
+}

--- a/oxbow/src/lib.rs
+++ b/oxbow/src/lib.rs
@@ -33,4 +33,5 @@ pub mod bcf;
 pub mod bigbed;
 pub mod bigwig;
 pub mod gff;
+pub mod gtf;
 pub mod vcf;

--- a/oxbow/src/lib.rs
+++ b/oxbow/src/lib.rs
@@ -32,4 +32,5 @@ pub mod vpos;
 pub mod bcf;
 pub mod bigbed;
 pub mod bigwig;
+pub mod gff;
 pub mod vcf;

--- a/py-oxbow/Cargo.lock
+++ b/py-oxbow/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "noodles-fasta",
  "noodles-fastq",
  "noodles-gff",
+ "noodles-gtf",
  "noodles-sam",
  "noodles-tabix",
  "noodles-vcf",
@@ -918,6 +919,17 @@ dependencies = [
  "noodles-core",
  "noodles-csi",
  "percent-encoding",
+]
+
+[[package]]
+name = "noodles-gtf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "096367bb382b244da2dc087a9628daecae299a5641f6572f28627f2001187465"
+dependencies = [
+ "noodles-bgzf",
+ "noodles-core",
+ "noodles-csi",
 ]
 
 [[package]]

--- a/py-oxbow/Cargo.lock
+++ b/py-oxbow/Cargo.lock
@@ -801,6 +801,7 @@ dependencies = [
  "noodles-csi",
  "noodles-fasta",
  "noodles-fastq",
+ "noodles-gff",
  "noodles-sam",
  "noodles-tabix",
  "noodles-vcf",
@@ -904,6 +905,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1763486d2d1a1e39a86676a47aa05728c75f73f0f883415e36439711ead2641"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "noodles-gff"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29cd6131bf39317a7b222eab0e99f3a14559e02a2a8c22e6160f66d17a513b74"
+dependencies = [
+ "indexmap 2.0.0",
+ "noodles-bgzf",
+ "noodles-core",
+ "noodles-csi",
+ "percent-encoding",
 ]
 
 [[package]]

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -15,6 +15,7 @@ use oxbow::fastq::FastqReader;
 use oxbow::vcf;
 // use oxbow::cram::CramReader;
 use oxbow::bcf::BcfReader;
+use oxbow::gff::GffReader;
 use oxbow::vcf::VcfReader;
 
 use oxbow::vpos;
@@ -266,7 +267,12 @@ fn read_bigwig(
 }
 
 #[pyfunction]
-fn read_bigbed(py: Python, path_or_file_like: PyObject, region: Option<&str>, fields: Option<HashSet<&str>>) -> PyObject {
+fn read_bigbed(
+    py: Python,
+    path_or_file_like: PyObject,
+    region: Option<&str>,
+    fields: Option<HashSet<&str>>,
+) -> PyObject {
     if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
         // If it's a string, treat it as a path
         let mut reader = BigBedReader::new_from_path(string_ref.to_str().unwrap()).unwrap();
@@ -280,6 +286,25 @@ fn read_bigbed(py: Python, path_or_file_like: PyObject, region: Option<&str>, fi
         };
         let mut reader = BigBedReader::new(file_like).unwrap();
         let ipc = reader.records_to_ipc(region, fields).unwrap();
+        Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+    }
+}
+
+#[pyfunction]
+fn read_gff(py: Python, path_or_file_like: PyObject) -> PyObject {
+    if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
+        // If it's a string, treat it as a path
+        let mut reader = GffReader::new_from_path(string_ref.to_str().unwrap()).unwrap();
+        let ipc = reader.records_to_ipc().unwrap();
+        Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+    } else {
+        // Otherwise, treat it as file-like
+        let file_like = match PyFileLikeObject::new(path_or_file_like, true, false, true) {
+            Ok(file_like) => file_like,
+            Err(_) => panic!("Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object."),
+        };
+        let mut reader = GffReader::new(file_like).unwrap();
+        let ipc = reader.records_to_ipc().unwrap();
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     }
 }
@@ -300,5 +325,6 @@ fn py_oxbow(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_bcf_vpos, m)?)?;
     m.add_function(wrap_pyfunction!(read_bigwig, m)?)?;
     m.add_function(wrap_pyfunction!(read_bigbed, m)?)?;
+    m.add_function(wrap_pyfunction!(read_gff, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## GFF and GFF Readers

### GFF
Doesn't pull out metadata directives or handle tabix indexing.

#### Usage
```python
import oxbow as ox
import polars as pl

ipc = ox.read_gff("../fixtures/example.gff")
df = pl.read_ipc(ipc)
df
```

![image](https://github.com/abdenlab/oxbow/assets/56460265/0656df69-b16c-4901-9574-65c1cad823b6)

### GTF

#### Usage
```python
ipc = ox.read_gtf("../fixtures/example.gtf")
df = pl.read_ipc(ipc)
df
```

![image](https://github.com/abdenlab/oxbow/assets/56460265/216eea72-4c26-4a14-90ef-169e89046581)

Note that `score`, `phase`, and `frame` values parsed as `None` by Noodles will be `null` and not `"."`. `phase` and `frame` are a little odd since they are represented as strings with expected values of "0", "1", or "2" and Noodles implements them differently internally.
