### PR TITLE
Return references from BAM file

### DIFF
--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -10,7 +10,6 @@ use arrow::array::{
 use arrow::ipc::writer::FileWriter;
 use arrow::{datatypes::Int32Type, error::ArrowError, record_batch::RecordBatch};
 use noodles::core::Region;
-use noodles::vcf::record::info::field::key::SV_LENGTHS;
 use noodles::{bam, bgzf, csi, sam};
 
 use crate::batch_builder::{write_ipc_err, BatchBuilder};
@@ -135,7 +134,7 @@ impl<R: Read + Seek> BamReader<R> {
 /// ```no_run
 /// use oxbow::bam::references_to_ipc;
 ///
-/// let file = std::fs::File::open("sample.bam")?;
+/// let file = std::fs::File::open("sample.bam").unwrap();
 /// let ipc = references_to_ipc(file).unwrap();
 /// ```
 pub fn references_to_ipc<R: Read + Seek>(read: R) -> Result<Vec<u8>, ArrowError> {

--- a/oxbow/src/bigbed.rs
+++ b/oxbow/src/bigbed.rs
@@ -254,7 +254,9 @@ impl BatchBuilder for BigBedBatchBuilder {
                 for (builder, col) in
                     std::iter::zip(columns.iter_mut(), record.rest.split_whitespace())
                 {
-                    let Some((_, builder)) = builder else { continue };
+                    let Some((_, builder)) = builder else {
+                        continue;
+                    };
                     match builder {
                         Column::Int(builder) => {
                             let value: i32 = col.replace(",", "").parse().unwrap();

--- a/py-oxbow/Cargo.lock
+++ b/py-oxbow/Cargo.lock
@@ -1086,9 +1086,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -7,6 +7,7 @@ use pyo3::types::PyString;
 
 use oxbow::bam;
 use oxbow::bam::BamReader;
+use oxbow::bam::references_to_ipc;
 use oxbow::bcf;
 use oxbow::bigbed::BigBedReader;
 use oxbow::bigwig::BigWigReader;
@@ -105,29 +106,16 @@ fn read_bam_vpos(
 #[pyfunction]
 fn read_bam_references(
     py: Python,
-    path_or_file_like: PyObject,
-    index: Option<PyObject>,
+    file_like: PyObject
 ) -> PyObject {
-    if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
-        // If it's a string, treat it as a path
-        let mut reader = BamReader::new_from_path(string_ref.to_str().unwrap()).unwrap();
-        let ipc = reader.references_to_ipc().unwrap();
-        Python::with_gil(|py| PyBytes::new(py, &ipc).into())
-    } else {
-        // Otherwise, treat it as file-like
-        let file_like = match PyFileLikeObject::new(path_or_file_like, true, false, true) {
-            Ok(file_like) => file_like,
-            Err(_) => panic!("Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object."),
-        };
-        let index_file_like = match PyFileLikeObject::new(index.unwrap(), true, false, true) {
-            Ok(file_like) => file_like,
-            Err(_) => panic!("Unknown argument for `index`. Not a file path string or url, and not a file-like object."),
-        };
-        let index = bam::index_from_reader(index_file_like).unwrap();
-        let mut reader = BamReader::new(file_like, index).unwrap();
-        let ipc = reader.references_to_ipc().unwrap();
-        Python::with_gil(|py| PyBytes::new(py, &ipc).into())
-    }
+    // Otherwise, treat it as file-like
+    let _file_like = match PyFileLikeObject::new(file_like, true, false, true) {
+        Ok(_file_like) => _file_like,
+        Err(_) => panic!("Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object."),
+    };
+
+    let ipc = references_to_ipc(_file_like).unwrap();
+    Python::with_gil(|py| PyBytes::new(py, &ipc).into())
 }
 
 #[pyfunction]


### PR DESCRIPTION
Added an API function that returns the reference sequences from the bam file.

Example usage:

```
f = open('my.bam', 'r')
ipc = ox.read_bam_references(f)
pl.read_ipc(ipc)
```

This returns a polars dataframe with two columns `name` and `length` that has the reference names and lengths.