### PR TITLE
feat(bam): Parse tags into StructArray

### DIFF
--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -5,9 +5,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, Float32Builder, GenericStringBuilder, Int16Builder, Int32Array,
-    Int32Builder, Int8Builder, StringArray, StringDictionaryBuilder, StructArray,
-    UInt16Array, UInt16Builder, UInt32Builder, UInt8Array, UInt8Builder,
+    ArrayRef, Float32Builder, GenericStringBuilder, Int16Builder, Int32Array, Int32Builder,
+    Int8Builder, StringArray, StringDictionaryBuilder, StructArray, UInt16Array, UInt16Builder,
+    UInt32Builder, UInt8Array, UInt8Builder,
 };
 use arrow::{datatypes::Int32Type, error::ArrowError, record_batch::RecordBatch};
 use noodles::core::Region;

--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -185,9 +185,7 @@ impl TagsBuilder {
                 Some(Value::Character(v)) => {
                     let builder = self.inner.entry(*tag).or_insert_with(|| {
                         let mut builder = GenericStringBuilder::<i32>::new();
-                        for _ in 0..self.seen {
-                            builder.append_null();
-                        }
+                        builder.extend(std::iter::repeat(None::<&str>).take(self.seen));
                         TagArrayBuilder::Character(builder)
                     });
                     match builder {
@@ -291,9 +289,7 @@ impl TagsBuilder {
                 Some(Value::String(v)) => {
                     let builder = self.inner.entry(*tag).or_insert_with(|| {
                         let mut builder = GenericStringBuilder::<i32>::new();
-                        for _ in 0..self.seen {
-                            builder.append_null();
-                        }
+                        builder.extend(std::iter::repeat(None::<&str>).take(self.seen));
                         TagArrayBuilder::String(builder)
                     });
                     match builder {
@@ -306,9 +302,7 @@ impl TagsBuilder {
                 Some(Value::Hex(v)) => {
                     let builder = self.inner.entry(*tag).or_insert_with(|| {
                         let mut builder = GenericStringBuilder::<i32>::new();
-                        for _ in 0..self.seen {
-                            builder.append_null();
-                        }
+                        builder.extend(std::iter::repeat(None::<&str>).take(self.seen));
                         TagArrayBuilder::Hex(builder)
                     });
                     match builder {


### PR DESCRIPTION
Generalization of #40 using arrow primatives (Arrow `StructArray`) to handle nesting.

- Uses correct data type for each tag (not just strings)
- Parses tags into one column (as a single struct array)
- The struct column can be exploded lazily (in python)

```python
import oxbow
import polars as pl

ipc = oxbow.read_bam("data.bam")
df = pl.read_ipc(ipc)
df.get_column("tags").struct.unnest()
```

Next step is to allow "picking" (or omitting) different tags to handle in the `TagBuilder`.
