### PR TITLE
Refactor fasta reader index usage and allow filelike object use

### DIFF
--- a/oxbow/src/fasta.rs
+++ b/oxbow/src/fasta.rs
@@ -23,9 +23,9 @@ pub fn new_from_reader<R>(fasta: R, fai: R) -> io::Result<fasta::IndexedReader<B
 where
     R: io::Read,
 {
-    let fasta_reader = BufReader::new(fasta);
-    let index: fasta::fai::Index = fasta::fai::Reader::new(BufReader::new(fai)).read_index()?;
-    Ok(fasta::IndexedReader::new(fasta_reader, index))
+    fasta::indexed_reader::Builder::default()
+        .set_index(fasta::fai::Reader::new(BufReader::new(fai)).read_index()?)
+        .build_from_reader(BufReader::new(fasta))
 }
 
 /// Returns the records in the given region as Apache Arrow IPC.

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -32,11 +32,32 @@ fn partition_from_index_file(path: &str, chunksize: u64) -> PyObject {
 }
 
 #[pyfunction]
-fn read_fasta(path: &str, region: Option<&str>) -> PyObject {
-    // Only reads from path since PyFileLikeObject does not currently implement a BufRead trait
-    let reader = fasta::new_from_path(path).unwrap();
-    let ipc = fasta::records_to_ipc(reader, region).unwrap();
-    Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+fn read_fasta(
+    py: Python,
+    path_or_file_like: PyObject,
+    region: Option<&str>,
+    index: Option<PyObject>,
+) -> PyObject {
+    if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
+        // If it's a string, treat it as a path
+        // The underlying builder for the IndexedReader will use both the fasta file and fai index file
+        let reader = fasta::new_from_path(string_ref.to_str().unwrap()).unwrap();
+        let ipc = fasta::records_to_ipc(reader, region).unwrap();
+        Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+    } else {
+        // Otherwise, treat it as file-like
+        let fasta_file_like = match PyFileLikeObject::new(path_or_file_like, true, false, true) {
+            Ok(file_like) => file_like,
+            Err(_) => panic!("Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object."),
+        };
+        let index_file_like = match PyFileLikeObject::new(index.unwrap(), true, false, true) {
+            Ok(file_like) => file_like,
+            Err(_) => panic!("Unknown argument for `index`. Not a file path string or url, and not a file-like object."),
+        };
+        let reader = fasta::new_from_reader(fasta_file_like, index_file_like).unwrap();
+        let ipc = fasta::records_to_ipc(reader, region).unwrap();
+        Python::with_gil(|py| PyBytes::new(py, &ipc).into())
+    }
 }
 
 #[pyfunction]

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -10,7 +10,7 @@ use oxbow::bam::BamReader;
 use oxbow::bcf;
 use oxbow::bigbed::BigBedReader;
 use oxbow::bigwig::BigWigReader;
-use oxbow::fasta::FastaReader;
+use oxbow::fasta;
 use oxbow::fastq::FastqReader;
 use oxbow::vcf;
 // use oxbow::cram::CramReader;
@@ -32,31 +32,11 @@ fn partition_from_index_file(path: &str, chunksize: u64) -> PyObject {
 }
 
 #[pyfunction]
-fn read_fasta(
-    py: Python,
-    path_or_file_like: PyObject,
-    region: Option<&str>,
-    index: Option<PyObject>,
-) -> PyObject {
-    if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
-        let mut reader = FastaReader::new_from_path(string_ref.to_str().unwrap()).unwrap();
-        let ipc = reader.records_to_ipc(region).unwrap();
-        Python::with_gil(|py| PyBytes::new(py, &ipc).into())
-    } else {
-        // Otherwise, treat it as file-like
-        let file_like = match PyFileLikeObject::new(path_or_file_like, true, false, true) {
-            Ok(file_like) => file_like,
-            Err(_) => panic!("Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object."),
-        };
-        let index_file_like = match PyFileLikeObject::new(index.unwrap(), true, false, true) {
-            Ok(file_like) => file_like,
-            Err(_) => panic!("Unknown argument for `index`. Not a file path string or url, and not a file-like object."),
-        };
-        let index = oxbow::fasta::index_from_reader(index_file_like).unwrap();
-        let mut reader = FastaReader::new(file_like, index).unwrap();
-        let ipc = reader.records_to_ipc(region).unwrap();
-        Python::with_gil(|py| PyBytes::new(py, &ipc).into())
-    }
+fn read_fasta(path: &str, region: Option<&str>) -> PyObject {
+    // Only reads from path since PyFileLikeObject does not currently implement a BufRead trait
+    let reader = fasta::new_from_path(path).unwrap();
+    let ipc = fasta::records_to_ipc(reader, region).unwrap();
+    Python::with_gil(|py| PyBytes::new(py, &ipc).into())
 }
 
 #[pyfunction]


### PR DESCRIPTION
The fasta implementation was a little tricky since there are multiple relevant readers upstream in noodles: `fasta::Reader`, `fasta::IndexedReader`, and `fasta::fai::Reader`. The core `records_to_ipc` function relies on the `query` method supplied by the `fasta::Reader`, so the `fasta::Reader` was turned into a `FastaReader` struct field. Since the `query` method also relies on the fasta index, `index` was made into a `FastaReader` struct field and is now read through a separate `fasta::fai::Reader` instead of using the `fasta::IndexedReader`, which has access to the index, but ~lacks the `query` method~. (EDIT: yes it does have a `query` method)

Filelike object compatability was also implemented in line with the other readers, and generics have been sprinkled about accordingly.

Also now provides a proper error message when a `.fai` index file can't be found instead of providing a generic "file not found" error which a user may attribute to the fasta file and not the index file.