### PR TITLE
Simplify GFF/GTF reader types

### DIFF
--- a/oxbow/src/gff.rs
+++ b/oxbow/src/gff.rs
@@ -9,24 +9,18 @@ use noodles::gff;
 
 use crate::batch_builder::{write_ipc_err, BatchBuilder};
 
-/// A GFF reader.
 pub struct GffReader<R> {
-    reader: gff::Reader<BufReader<R>>,
+    reader: gff::Reader<R>,
 }
 
 impl GffReader<BufReader<File>> {
-    /// Creates a GFF reader from a given file path.
     pub fn new_from_path(path: &str) -> std::io::Result<Self> {
-        let reader = File::open(path)
-            .map(BufReader::new)
-            .map(BufReader::new)
-            .map(gff::Reader::new)?;
+        let reader = File::open(path).map(BufReader::new).map(gff::Reader::new)?;
         Ok(Self { reader })
     }
 }
 
-impl<R: Read + Seek> GffReader<R> {
-    /// Creates a GFF Reader.
+impl<R: Read + Seek> GffReader<BufReader<R>> {
     pub fn new(read: R) -> std::io::Result<Self> {
         let reader = gff::Reader::new(BufReader::new(read));
         Ok(Self { reader })

--- a/oxbow/src/gtf.rs
+++ b/oxbow/src/gtf.rs
@@ -9,24 +9,18 @@ use noodles::gtf;
 
 use crate::batch_builder::{write_ipc_err, BatchBuilder};
 
-/// A GTF reader.
 pub struct GtfReader<R> {
-    reader: gtf::Reader<BufReader<R>>,
+    reader: gtf::Reader<R>,
 }
 
 impl GtfReader<BufReader<File>> {
-    /// Creates a GTF reader from a given file path.
     pub fn new_from_path(path: &str) -> std::io::Result<Self> {
-        let reader = File::open(path)
-            .map(BufReader::new)
-            .map(BufReader::new)
-            .map(gtf::Reader::new)?;
+        let reader = File::open(path).map(BufReader::new).map(gtf::Reader::new)?;
         Ok(Self { reader })
     }
 }
 
-impl<R: Read + Seek> GtfReader<R> {
-    /// Creates a GTF Reader.
+impl<R: Read + Seek> GtfReader<BufReader<R>> {
     pub fn new(read: R) -> std::io::Result<Self> {
         let reader = gtf::Reader::new(BufReader::new(read));
         Ok(Self { reader })


### PR DESCRIPTION
Moves the `BufReader` out of the struct field type signatures