### PR TITLE
Use `BufReader` for `PyFileLikeObject` with 1MB buffer

### DIFF
--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -15,7 +15,7 @@ use noodles::sam::record::data::field::Tag;
 use noodles::sam::record::Data;
 use noodles::{bam, bgzf, csi, sam};
 
-use crate::batch_builder::{write_ipc_err, BatchBuilder};
+use crate::batch_builder::{write_ipc_err, BatchBuilder, BUFFER_SIZE_BYTES};
 
 pub fn index_from_reader<R>(mut read: R) -> io::Result<csi::Index>
 where
@@ -60,7 +60,7 @@ impl BamReader<BufReader<File>> {
     pub fn new_from_path(path: &str) -> std::io::Result<Self> {
         let index = index_from_path(path)?;
         let file = std::fs::File::open(path)?;
-        let buf_file = std::io::BufReader::with_capacity(1024 * 1024, file);
+        let buf_file = std::io::BufReader::with_capacity(BUFFER_SIZE_BYTES, file);
         let mut reader = bam::Reader::new(buf_file);
         let header = reader.read_header()?;
         Ok(Self {

--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -17,22 +17,20 @@ use noodles::{bam, bgzf, csi, sam};
 
 use crate::batch_builder::{write_ipc_err, BatchBuilder};
 
-pub fn index_from_reader<R>(read: R) -> io::Result<csi::Index>
+pub fn index_from_reader<R>(mut read: R) -> io::Result<csi::Index>
 where
     R: Read + Seek,
 {
     // Unlike .tbi and .csi, .bai is not bgzf-compressed
     // so we read off the magic directly.
-    let mut buf_read = std::io::BufReader::with_capacity(1024 * 1024, read);
-
     let mut magic = [0; 4];
-    buf_read.read_exact(&mut magic)?;
-    buf_read.seek(io::SeekFrom::Start(0))?;
+    read.read_exact(&mut magic)?;
+    read.seek(io::SeekFrom::Start(0))?;
     if magic == b"BAI\x01" as &[u8] {
-        let mut bai_reader = bam::bai::Reader::new(buf_read);
+        let mut bai_reader = bam::bai::Reader::new(read);
         bai_reader.read_index()
     } else {
-        let mut csi_reader = csi::Reader::new(buf_read);
+        let mut csi_reader = csi::Reader::new(read);
         csi_reader.read_index()
     }
 }
@@ -73,11 +71,13 @@ impl BamReader<BufReader<File>> {
     }
 }
 
-impl<R: Read + Seek> BamReader<BufReader<R>> {
+impl<R> BamReader<R>
+where
+    R: Read + Seek,
+{
     /// Creates a BAM reader.
     pub fn new(read: R, index: csi::Index) -> std::io::Result<Self> {
-        let buf_read = std::io::BufReader::with_capacity(1024 * 1024, read);
-        let mut reader = bam::Reader::new(buf_read);
+        let mut reader = bam::Reader::new(read);
         let header = reader.read_header()?;
         Ok(Self {
             reader,

--- a/oxbow/src/batch_builder.rs
+++ b/oxbow/src/batch_builder.rs
@@ -37,3 +37,8 @@ pub fn finish_batch(batch_builder: impl BatchBuilder) -> Result<Vec<u8>, ArrowEr
     writer.finish()?;
     writer.into_inner()
 }
+
+/// Size of the buffer to use when reading files (1MB).
+///
+/// Larger than default for `std::io::BufReader::new()` (8KB).
+pub const BUFFER_SIZE_BYTES: usize = const { 1024 * 1024 };

--- a/oxbow/src/bcf.rs
+++ b/oxbow/src/bcf.rs
@@ -11,7 +11,7 @@ use arrow::{datatypes::Int32Type, error::ArrowError, record_batch::RecordBatch};
 use noodles::core::Region;
 use noodles::{bcf, bgzf, csi, vcf};
 
-use crate::batch_builder::{write_ipc_err, BatchBuilder};
+use crate::batch_builder::{write_ipc_err, BatchBuilder, BUFFER_SIZE_BYTES};
 
 pub fn index_from_reader<R>(read: R) -> io::Result<csi::Index>
 where
@@ -32,7 +32,7 @@ impl BcfReader<BufReader<File>> {
     pub fn new_from_path(path: &str) -> std::io::Result<Self> {
         let index = csi::read(format!("{}.csi", path))?;
         let file = std::fs::File::open(path)?;
-        let buf_file = std::io::BufReader::with_capacity(1024 * 1024, file);
+        let buf_file = std::io::BufReader::with_capacity(BUFFER_SIZE_BYTES, file);
         let mut reader = bcf::Reader::new(buf_file);
         let header = reader.read_header()?;
         Ok(Self {

--- a/oxbow/src/cram.rs
+++ b/oxbow/src/cram.rs
@@ -36,11 +36,11 @@ impl CramReader {
 
         // Open the CRAM file
         let file = std::fs::File::open(path)?;
-        let bufreader = std::io::BufReader::with_capacity(1024 * 1024, file);
+        let bufreader = std::io::BufReader::with_capacity(BUFFER_SIZE_BYTES, file);
         let mut reader = cram::indexed_reader::IndexedReader::new(bufreader, index);
         reader.read_file_definition()?;
         let header = reader.read_file_header()?;
-        
+
         Ok(Self { reader, header, repository })
     }
 

--- a/oxbow/src/fasta.rs
+++ b/oxbow/src/fasta.rs
@@ -5,7 +5,7 @@ use noodles::fasta;
 use noodles::fasta::fai;
 use std::sync::Arc;
 
-use crate::batch_builder::{write_ipc, BatchBuilder};
+use crate::batch_builder::{write_ipc, BatchBuilder, BUFFER_SIZE_BYTES};
 
 type BufferedReader = std::io::BufReader<std::fs::File>;
 
@@ -20,7 +20,7 @@ impl FastaReader {
     pub fn new(path: &str) -> std::io::Result<Self> {
         let index = fai::read(format!("{}.fai", path))?;
         let file = std::fs::File::open(path)?;
-        let bufreader = std::io::BufReader::with_capacity(1024 * 1024, file);
+        let bufreader = std::io::BufReader::with_capacity(BUFFER_SIZE_BYTES, file);
         let reader = fasta::indexed_reader::Builder::default()
             .set_index(index)
             .build_from_reader(bufreader)?;

--- a/oxbow/src/fastq.rs
+++ b/oxbow/src/fastq.rs
@@ -3,7 +3,7 @@ use arrow::{error::ArrowError, record_batch::RecordBatch};
 use noodles::fastq;
 use std::{
     fs::File,
-    io::{self, BufReader, Read},
+    io::{self, BufRead, BufReader, Read},
     str,
     sync::Arc,
 };
@@ -23,9 +23,12 @@ impl FastqReader<BufReader<File>> {
     }
 }
 
-impl<R: Read> FastqReader<BufReader<R>> {
+impl<R> FastqReader<R>
+where
+    R: BufRead,
+{
     pub fn new(read: R) -> io::Result<Self> {
-        let reader = fastq::Reader::new(BufReader::new(read));
+        let reader = fastq::Reader::new(read);
         Ok(Self { reader })
     }
 

--- a/oxbow/src/fastq.rs
+++ b/oxbow/src/fastq.rs
@@ -3,7 +3,7 @@ use arrow::{error::ArrowError, record_batch::RecordBatch};
 use noodles::fastq;
 use std::{
     fs::File,
-    io::{self, BufRead, BufReader, Read},
+    io::{self, BufRead, BufReader},
     str,
     sync::Arc,
 };

--- a/oxbow/src/gff.rs
+++ b/oxbow/src/gff.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Seek};
+use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Float32Builder, GenericStringBuilder, Int32Builder};

--- a/oxbow/src/gff.rs
+++ b/oxbow/src/gff.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufReader, Read, Seek};
+use std::io::{BufRead, BufReader, Read, Seek};
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Float32Builder, GenericStringBuilder, Int32Builder};
@@ -20,9 +20,12 @@ impl GffReader<BufReader<File>> {
     }
 }
 
-impl<R: Read + Seek> GffReader<BufReader<R>> {
+impl<R> GffReader<R>
+where
+    R: BufRead,
+{
     pub fn new(read: R) -> std::io::Result<Self> {
-        let reader = gff::Reader::new(BufReader::new(read));
+        let reader = gff::Reader::new(read);
         Ok(Self { reader })
     }
 
@@ -42,7 +45,7 @@ impl<R: Read + Seek> GffReader<BufReader<R>> {
             .reader
             .records()
             .map(|i| i.map_err(|e| ArrowError::ExternalError(e.into())));
-        return write_ipc_err(records, batch_builder);
+        write_ipc_err(records, batch_builder)
     }
 }
 

--- a/oxbow/src/gtf.rs
+++ b/oxbow/src/gtf.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufRead, BufReader, Seek};
+use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Float32Builder, GenericStringBuilder, Int32Builder};

--- a/oxbow/src/gtf.rs
+++ b/oxbow/src/gtf.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufReader, Read, Seek};
+use std::io::{BufRead, BufReader, Seek};
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Float32Builder, GenericStringBuilder, Int32Builder};
@@ -20,9 +20,12 @@ impl GtfReader<BufReader<File>> {
     }
 }
 
-impl<R: Read + Seek> GtfReader<BufReader<R>> {
+impl<R> GtfReader<R>
+where
+    R: BufRead,
+{
     pub fn new(read: R) -> std::io::Result<Self> {
-        let reader = gtf::Reader::new(BufReader::new(read));
+        let reader = gtf::Reader::new(read);
         Ok(Self { reader })
     }
 
@@ -42,7 +45,7 @@ impl<R: Read + Seek> GtfReader<BufReader<R>> {
             .reader
             .records()
             .map(|i| i.map_err(|e| ArrowError::ExternalError(e.into())));
-        return write_ipc_err(records, batch_builder);
+        write_ipc_err(records, batch_builder)
     }
 }
 

--- a/oxbow/src/vcf.rs
+++ b/oxbow/src/vcf.rs
@@ -11,7 +11,7 @@ use arrow::{datatypes::Int32Type, error::ArrowError, record_batch::RecordBatch};
 use noodles::core::Region;
 use noodles::{bgzf, csi, tabix, vcf};
 
-use crate::batch_builder::{write_ipc_err, BatchBuilder};
+use crate::batch_builder::{write_ipc_err, BatchBuilder, BUFFER_SIZE_BYTES};
 
 fn read_magic(read: &mut dyn Read) -> io::Result<[u8; 4]> {
     let mut magic = [0; 4];
@@ -59,7 +59,7 @@ impl VcfReader<BufReader<File>> {
     pub fn new_from_path(path: &str) -> std::io::Result<Self> {
         let index = index_from_path(path)?;
         let file = std::fs::File::open(path)?;
-        let buf_file = std::io::BufReader::with_capacity(1024 * 1024, file);
+        let buf_file = std::io::BufReader::with_capacity(BUFFER_SIZE_BYTES, file);
         let mut reader = vcf::Reader::new(bgzf::Reader::new(buf_file));
         let header = reader.read_header()?;
         Ok(Self {

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -53,8 +53,8 @@ fn read_fastq(py: Python, path_or_file_like: PyObject) -> PyObject {
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     } else {
         // Otherwise, treat it as file-like
-        // No BufReader here because FastqReader already has its own
         let file_like = PyFileLikeObject::new(path_or_file_like, true, false, true)
+            .map(into_bufreader)
             .expect("Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object.");
         let mut reader = FastqReader::new(file_like).unwrap();
         let ipc = reader.records_to_ipc().unwrap();
@@ -303,8 +303,8 @@ fn read_gff(py: Python, path_or_file_like: PyObject) -> PyObject {
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     } else {
         // Otherwise, treat it as file-like
-        // No BufReader here because GffReader already has its own
         let file_like = PyFileLikeObject::new(path_or_file_like, true, false, true)
+            .map(into_bufreader)
             .expect("Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object.");
         let mut reader = GffReader::new(file_like).unwrap();
         let ipc = reader.records_to_ipc().unwrap();
@@ -321,10 +321,9 @@ fn read_gtf(py: Python, path_or_file_like: PyObject) -> PyObject {
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())
     } else {
         // Otherwise, treat it as file-like
-        // No BufReader here because GtfReader already has its own
         let file_like = PyFileLikeObject::new(path_or_file_like, true, false, true)
+            .map(into_bufreader)
             .expect("Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object.");
-
         let mut reader = GtfReader::new(file_like).unwrap();
         let ipc = reader.records_to_ipc().unwrap();
         Python::with_gil(|py| PyBytes::new(py, &ipc).into())

--- a/py-oxbow/src/lib.rs
+++ b/py-oxbow/src/lib.rs
@@ -31,7 +31,7 @@ use file_like::PyFileLikeObject;
 fn buffered_file_like(path_or_file_like: PyObject) -> PyResult<BufReader<PyFileLikeObject>> {
     PyFileLikeObject::new(path_or_file_like, true, false, true)
         // Alternative to `std::io::BufReader::new` with a larger buffer size (1MB instead of 8KB).
-        .map(|file_like| BufReader::with_capacity(1024 * 1024, file_like))
+        .map(|file_like| BufReader::with_capacity(const { 1024 * 1024 }, file_like))
 }
 
 #[pyfunction]


### PR DESCRIPTION
Wraps `PyFileLikeObject` in `BufReader` with a 1MB buffer for BAM, BCF,
VCF, and BigWig readers. Avoids changing the behavior of `new` to
prevent baking in assumptions about buffering needs or sizes, preserving
flexibility for unbuffered use cases.

-----

Follow-up to #68

We want to avoid setting up the buffer inside `new` because it bakes in an opinion about buffering, which might conflict with cases where readers are already buffered, and it removes flexibility for users to configure buffer sizes or avoid buffering entirely if our choices are undesirable for their use case.

