### PR TITLE
Enforce `cargo clippy` and `cargo check` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,21 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update
 
-      - name: Check formatting
+      # Typechecking
+      - name: Run Cargo Check
+        run: cargo check --all-targets --all-features
+
+      # Linting
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      # Assert Formatting
+      - name: Check Formatting
         run: cargo fmt --all --check
 
+      # Tests
       - name: Download fixtures
         run: cd fixtures && wget -i list.txt
 
-      - name: Run cargo test
+      - name: Run Tests
         run: cargo test

--- a/oxbow/src/bam.rs
+++ b/oxbow/src/bam.rs
@@ -401,7 +401,7 @@ impl<'a> BamBatchBuilder<'a> {
     }
 }
 
-impl<'a> BatchBuilder for BamBatchBuilder<'a> {
+impl BatchBuilder for BamBatchBuilder<'_> {
     type Record<'x> = &'x sam::alignment::Record;
 
     fn push(&mut self, record: Self::Record<'_>) {
@@ -493,7 +493,7 @@ where
     }
 }
 
-impl<'a, R> Iterator for BamRecords<'a, R>
+impl<R> Iterator for BamRecords<'_, R>
 where
     R: Read + Seek,
 {

--- a/oxbow/src/bcf.rs
+++ b/oxbow/src/bcf.rs
@@ -206,7 +206,7 @@ where
     }
 }
 
-impl<'a, R> Iterator for BcfRecords<'a, R>
+impl<R> Iterator for BcfRecords<'_, R>
 where
     R: Read + Seek,
 {

--- a/oxbow/src/bigwig.rs
+++ b/oxbow/src/bigwig.rs
@@ -281,15 +281,24 @@ impl ValueToIpc for Summary {
     type Schema = std::iter::Flatten<std::array::IntoIter<Option<(&'static str, ArrayRef)>, 6>>;
 
     fn append_value_to(self, builder: &mut Self::Builder) {
-        builder.0.as_mut().map(|b| b.append_value(self.total_items));
-        builder
-            .1
-            .as_mut()
-            .map(|b| b.append_value(self.bases_covered));
-        builder.2.as_mut().map(|b| b.append_value(self.min_val));
-        builder.3.as_mut().map(|b| b.append_value(self.max_val));
-        builder.4.as_mut().map(|b| b.append_value(self.sum));
-        builder.5.as_mut().map(|b| b.append_value(self.sum_squares));
+        if let Some(b) = builder.0.as_mut() {
+            b.append_value(self.total_items)
+        }
+        if let Some(b) = builder.1.as_mut() {
+            b.append_value(self.bases_covered)
+        }
+        if let Some(b) = builder.2.as_mut() {
+            b.append_value(self.min_val)
+        }
+        if let Some(b) = builder.3.as_mut() {
+            b.append_value(self.max_val)
+        }
+        if let Some(b) = builder.4.as_mut() {
+            b.append_value(self.sum)
+        }
+        if let Some(b) = builder.5.as_mut() {
+            b.append_value(self.sum_squares)
+        }
     }
     fn finish(mut builder: Self::Builder) -> Self::Schema {
         [

--- a/oxbow/src/fasta.rs
+++ b/oxbow/src/fasta.rs
@@ -24,7 +24,7 @@ impl FastaReader {
         let reader = fasta::indexed_reader::Builder::default()
             .set_index(index)
             .build_from_reader(bufreader)?;
-        let stream_reader = fasta::reader::Builder::default().build_from_path(path)?;
+        let stream_reader = fasta::reader::Builder.build_from_path(path)?;
         Ok(Self {
             reader,
             stream_reader,

--- a/oxbow/src/gff.rs
+++ b/oxbow/src/gff.rs
@@ -82,16 +82,16 @@ impl BatchBuilder for GffBatchBuilder {
 
     fn push(&mut self, record: Self::Record<'_>) {
         self.reference_sequence_name
-            .append_value(record.reference_sequence_name().to_string());
-        self.source.append_value(record.source().to_string());
-        self.ty.append_value(record.ty().to_string());
+            .append_value(record.reference_sequence_name());
+        self.source.append_value(record.source());
+        self.ty.append_value(record.ty());
         self.start.append_value(usize::from(record.start()) as i32);
         self.end.append_value(usize::from(record.end()) as i32);
         match record.score() {
             Some(score) => self.score.append_value(score),
             None => self.score.append_null(),
         }
-        self.strand.append_value(record.strand().to_string());
+        self.strand.append_value(record.strand());
         match record.phase() {
             Some(phase) => self.phase.append_value(phase),
             None => self.phase.append_null(),

--- a/oxbow/src/gtf.rs
+++ b/oxbow/src/gtf.rs
@@ -82,9 +82,9 @@ impl BatchBuilder for GtfBatchBuilder {
 
     fn push(&mut self, record: Self::Record<'_>) {
         self.reference_sequence_name
-            .append_value(record.reference_sequence_name().to_string());
-        self.source.append_value(record.source().to_string());
-        self.ty.append_value(record.ty().to_string());
+            .append_value(record.reference_sequence_name());
+        self.source.append_value(record.source());
+        self.ty.append_value(record.ty());
         self.start.append_value(usize::from(record.start()) as i32);
         self.end.append_value(usize::from(record.end()) as i32);
         match record.score() {
@@ -92,7 +92,7 @@ impl BatchBuilder for GtfBatchBuilder {
             None => self.score.append_null(),
         }
         match record.strand() {
-            Some(strand) => self.strand.append_value(strand.to_string()),
+            Some(strand) => self.strand.append_value(strand),
             None => self.strand.append_null(),
         }
         match record.frame() {

--- a/oxbow/src/vcf.rs
+++ b/oxbow/src/vcf.rs
@@ -233,7 +233,7 @@ where
     }
 }
 
-impl<'a, R> Iterator for VcfRecords<'a, R>
+impl<R> Iterator for VcfRecords<'_, R>
 where
     R: Read + Seek,
 {

--- a/oxbow/src/vpos.rs
+++ b/oxbow/src/vpos.rs
@@ -19,7 +19,7 @@ fn get_ref_last_position(rseq: &ReferenceSequence) -> bgzf::VirtualPosition {
 
 fn get_offsets_from_linear_index(rseq: &ReferenceSequence) -> Vec<(u64, u16)> {
     let mut offsets: Vec<(u64, u16)> = Vec::new();
-    let rend = get_ref_last_position(&rseq);
+    let rend = get_ref_last_position(rseq);
     for offset in rseq.linear_index() {
         let a = offset.compressed();
         let b = offset.uncompressed();
@@ -39,7 +39,7 @@ fn get_offsets_from_linear_index(rseq: &ReferenceSequence) -> Vec<(u64, u16)> {
 
 fn get_offsets_from_binning_index(rseq: &ReferenceSequence) -> Vec<(u64, u16)> {
     let mut offsets: Vec<(u64, u16)> = Vec::new();
-    let rend = get_ref_last_position(&rseq);
+    let rend = get_ref_last_position(rseq);
     for bin in rseq.bins().values() {
         for chunk in bin.chunks() {
             offsets.push((chunk.start().compressed(), chunk.start().uncompressed()));
@@ -55,7 +55,7 @@ fn get_offsets_from_binning_index(rseq: &ReferenceSequence) -> Vec<(u64, u16)> {
     offsets_uniq
 }
 
-fn consolidate_chunks(offsets: &Vec<(u64, u16)>, chunksize: u64) -> Vec<(u64, u16)> {
+fn consolidate_chunks(offsets: &[(u64, u16)], chunksize: u64) -> Vec<(u64, u16)> {
     let mut consolidated = Vec::new();
     let mut last_offset = 0;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.83"


### PR DESCRIPTION
Applys changes from `cargo clippy --fix` and touches up other linting
errors.
