### PR TITLE
Fixed schema bug in `GxfFile` and updated test cases

### DIFF
--- a/py-oxbow/oxbow/_core/function.py
+++ b/py-oxbow/oxbow/_core/function.py
@@ -245,12 +245,12 @@ class GxfFile(FunctionFile):
     ):
         self._index = index
         self._regions = regions
-        self.__schema_kwargs = dict(fields=fields)
         self.__scanner_kwargs = dict(compressed=compressed)
         super().__init__(uri, opener, fields)
         if attribute_defs is None:
             attribute_defs = self._scanner.attribute_defs(attribute_scan_rows)
         self.__scan_kwargs = dict(attribute_defs=attribute_defs, fields=fields)
+        self.__schema_kwargs = dict(fields=fields, attribute_defs=attribute_defs)
 
 
 class GffFile(GxfFile, file_type=FileType.GFF):

--- a/py-oxbow/tests/manifests/test_function.TestGffFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_function.TestGffFile.test_batches_callstack.yaml
@@ -20,10 +20,30 @@ GffFile("data/sample.gff", fields=('seqid', 'start', 'end')).batches(batch_size=
                 <-  {'compressed': 'False'}
             <-  builtins.PyGffScanner.<object>
             ->  oxbow._core.function.GxfFile._schema_kwargs
-            <-  {'fields': ("'seqid'", "'start'", "'end'")}
+            <-  {'fields': ("'seqid'", "'start'", "'end'"), 'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
         <-  seqid: string
             start: int32
             end: int32
+            attributes: struct<ID: string, Parent: string, ccdsid: string, exon_id: string, exon_number: string, gene_id: string, gene_name: string, gene_type: string, havana_gene: string, havana_transcript: string, hgnc_id: string, level: string, protein_id: string, tag: list<item: string>, transcript_id: string, transcript_name: string, transcript_support_level: string, transcript_type: string>
+              child 0, ID: string
+              child 1, Parent: string
+              child 2, ccdsid: string
+              child 3, exon_id: string
+              child 4, exon_number: string
+              child 5, gene_id: string
+              child 6, gene_name: string
+              child 7, gene_type: string
+              child 8, havana_gene: string
+              child 9, havana_transcript: string
+              child 10, hgnc_id: string
+              child 11, level: string
+              child 12, protein_id: string
+              child 13, tag: list<item: string>
+                  child 0, item: string
+              child 14, transcript_id: string
+              child 15, transcript_name: string
+              child 16, transcript_support_level: string
+              child 17, transcript_type: string
         ->  oxbow._core.base.DataFile.batches.<generator>
         <-  pyarrow.RecordBatch
             seqid: string

--- a/py-oxbow/tests/manifests/test_function.TestGffFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_function.TestGffFile.test_fragments_callstack.yaml
@@ -19,9 +19,29 @@ GffFile("data/sample.gff", fields=('seqid', 'start', 'end')).batches(batch_size=
                     <-  {'compressed': 'False'}
                 <-  builtins.PyGffScanner.<object>
                 ->  oxbow._core.function.GxfFile._schema_kwargs
-                <-  {'fields': ("'seqid'", "'start'", "'end'")}
+                <-  {'fields': ("'seqid'", "'start'", "'end'"), 'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
             <-  seqid: string
                 start: int32
                 end: int32
+                attributes: struct<ID: string, Parent: string, ccdsid: string, exon_id: string, exon_number: string, gene_id: string, gene_name: string, gene_type: string, havana_gene: string, havana_transcript: string, hgnc_id: string, level: string, protein_id: string, tag: list<item: string>, transcript_id: string, transcript_name: string, transcript_support_level: string, transcript_type: string>
+                  child 0, ID: string
+                  child 1, Parent: string
+                  child 2, ccdsid: string
+                  child 3, exon_id: string
+                  child 4, exon_number: string
+                  child 5, gene_id: string
+                  child 6, gene_name: string
+                  child 7, gene_type: string
+                  child 8, havana_gene: string
+                  child 9, havana_transcript: string
+                  child 10, hgnc_id: string
+                  child 11, level: string
+                  child 12, protein_id: string
+                  child 13, tag: list<item: string>
+                      child 0, item: string
+                  child 14, transcript_id: string
+                  child 15, transcript_name: string
+                  child 16, transcript_support_level: string
+                  child 17, transcript_type: string
         <-  oxbow._core.function.GxfFile._batch_readers.<locals>.<lambda>
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_function.TestGffFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_function.TestGffFile.test_select_callstack.yaml
@@ -37,7 +37,7 @@ GffFile("data/sample.gff").select(): |-
         ->  oxbow._core.function.GxfFile._scanner_kwargs
         <-  {'compressed': 'False'}
         ->  oxbow._core.function.GxfFile._schema_kwargs
-        <-  {'fields': 'None'}
+        <-  {'fields': 'None', 'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
         ->  oxbow._core.function.GxfFile.__init__("data/sample.gff", None, attribute_defs=[("ID", "String"), ("Parent", "String"), ("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), ("protein_id", "String"), ("tag", "Array"), ("transcript_id", "String"), ("transcript_name", "String"), ("transcript_support_level", "String"), ("transcript_type", "String")], fields=None, compressed=False)
             ->  oxbow._core.base.DataFile.__init__("data/sample.gff", None, None)
             <-  None
@@ -63,7 +63,7 @@ GffFile("data/sample.gff").select(): |-
                             <-  {'compressed': 'False'}
                         <-  builtins.PyGffScanner.<object>
                         ->  oxbow._core.function.GxfFile._schema_kwargs
-                        <-  {'fields': 'None'}
+                        <-  {'fields': 'None', 'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
                     <-  seqid: string
                         source: string
                         type: string
@@ -72,6 +72,26 @@ GffFile("data/sample.gff").select(): |-
                         score: float
                         strand: string
                         frame: uint8
+                        attributes: struct<ID: string, Parent: string, ccdsid: string, exon_id: string, exon_number: string, gene_id: string, gene_name: string, gene_type: string, havana_gene: string, havana_transcript: string, hgnc_id: string, level: string, protein_id: string, tag: list<item: string>, transcript_id: string, transcript_name: string, transcript_support_level: string, transcript_type: string>
+                          child 0, ID: string
+                          child 1, Parent: string
+                          child 2, ccdsid: string
+                          child 3, exon_id: string
+                          child 4, exon_number: string
+                          child 5, gene_id: string
+                          child 6, gene_name: string
+                          child 7, gene_type: string
+                          child 8, havana_gene: string
+                          child 9, havana_transcript: string
+                          child 10, hgnc_id: string
+                          child 11, level: string
+                          child 12, protein_id: string
+                          child 13, tag: list<item: string>
+                              child 0, item: string
+                          child 14, transcript_id: string
+                          child 15, transcript_name: string
+                          child 16, transcript_support_level: string
+                          child 17, transcript_type: string
                 <-  oxbow._core.function.GxfFile._batch_readers.<locals>.<lambda>
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_function.TestGtfFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_function.TestGtfFile.test_batches_callstack.yaml
@@ -20,10 +20,27 @@ GtfFile("data/sample.gtf", fields=('seqid', 'start', 'end')).batches(batch_size=
                 <-  {'compressed': 'False'}
             <-  builtins.PyGtfScanner.<object>
             ->  oxbow._core.function.GxfFile._schema_kwargs
-            <-  {'fields': ("'seqid'", "'start'", "'end'")}
+            <-  {'fields': ("'seqid'", "'start'", "'end'"), 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
         <-  seqid: string
             start: int32
             end: int32
+            attributes: struct<ccdsid: string, exon_id: string, exon_number: string, gene_id: string, gene_name: string, gene_type: string, havana_gene: string, havana_transcript: string, hgnc_id: string, level: string, protein_id: string, tag: string, transcript_id: string, transcript_name: string, transcript_support_level: string, transcript_type: string>
+              child 0, ccdsid: string
+              child 1, exon_id: string
+              child 2, exon_number: string
+              child 3, gene_id: string
+              child 4, gene_name: string
+              child 5, gene_type: string
+              child 6, havana_gene: string
+              child 7, havana_transcript: string
+              child 8, hgnc_id: string
+              child 9, level: string
+              child 10, protein_id: string
+              child 11, tag: string
+              child 12, transcript_id: string
+              child 13, transcript_name: string
+              child 14, transcript_support_level: string
+              child 15, transcript_type: string
         ->  oxbow._core.base.DataFile.batches.<generator>
         <-  pyarrow.RecordBatch
             seqid: string

--- a/py-oxbow/tests/manifests/test_function.TestGtfFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_function.TestGtfFile.test_fragments_callstack.yaml
@@ -19,9 +19,26 @@ GtfFile("data/sample.gtf", fields=('seqid', 'start', 'end')).batches(batch_size=
                     <-  {'compressed': 'False'}
                 <-  builtins.PyGtfScanner.<object>
                 ->  oxbow._core.function.GxfFile._schema_kwargs
-                <-  {'fields': ("'seqid'", "'start'", "'end'")}
+                <-  {'fields': ("'seqid'", "'start'", "'end'"), 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
             <-  seqid: string
                 start: int32
                 end: int32
+                attributes: struct<ccdsid: string, exon_id: string, exon_number: string, gene_id: string, gene_name: string, gene_type: string, havana_gene: string, havana_transcript: string, hgnc_id: string, level: string, protein_id: string, tag: string, transcript_id: string, transcript_name: string, transcript_support_level: string, transcript_type: string>
+                  child 0, ccdsid: string
+                  child 1, exon_id: string
+                  child 2, exon_number: string
+                  child 3, gene_id: string
+                  child 4, gene_name: string
+                  child 5, gene_type: string
+                  child 6, havana_gene: string
+                  child 7, havana_transcript: string
+                  child 8, hgnc_id: string
+                  child 9, level: string
+                  child 10, protein_id: string
+                  child 11, tag: string
+                  child 12, transcript_id: string
+                  child 13, transcript_name: string
+                  child 14, transcript_support_level: string
+                  child 15, transcript_type: string
         <-  oxbow._core.function.GxfFile._batch_readers.<locals>.<lambda>
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_function.TestGtfFile.test_select.yaml
+++ b/py-oxbow/tests/manifests/test_function.TestGtfFile.test_select.yaml
@@ -1,3 +1,4 @@
+fields=('nonexistent-field',), batch_size=3: 'Invalid field name: nonexistent-field'
 fields=('seqid', 'start', 'end'), batch_size=3:
     batch-00:
         attributes:

--- a/py-oxbow/tests/manifests/test_function.TestGtfFile.test_select.yaml
+++ b/py-oxbow/tests/manifests/test_function.TestGtfFile.test_select.yaml
@@ -1,0 +1,1648 @@
+fields=('seqid', 'start', 'end'), batch_size=3:
+    batch-00:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00000688402.1
+            exon_number: '2'
+            gene_id: ENSG00000137177.20
+            gene_name: KIF13A
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014313.9
+            havana_transcript: OTTHUMT00000039956.2
+            hgnc_id: HGNC:14566
+            level: '2'
+            protein_id: ENSP00000351150.6
+            tag: mRNA_start_NF
+            transcript_id: ENST00000358380.10
+            transcript_name: KIF13A-202
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        -   ccdsid: null
+            exon_id: ENSE00003554096.1
+            exon_number: '4'
+            gene_id: ENSG00000028203.19
+            gene_name: VEZT
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000170182.4
+            havana_transcript: OTTHUMT00000407816.2
+            hgnc_id: HGNC:18258
+            level: '2'
+            protein_id: ENSP00000380894.4
+            tag: mRNA_end_NF
+            transcript_id: ENST00000397792.8
+            transcript_name: VEZT-202
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        -   ccdsid: null
+            exon_id: ENSE00001350331.1
+            exon_number: '4'
+            gene_id: ENSG00000135541.22
+            gene_name: AHI1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000015631.9
+            havana_transcript: null
+            hgnc_id: HGNC:21575
+            level: '2'
+            protein_id: ENSP00000505809.1
+            tag: alternative_3_UTR
+            transcript_id: ENST00000680840.1
+            transcript_name: AHI1-242
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 17808930
+        - 95257239
+        - 135466373
+        seqid:
+        - chr6
+        - chr12
+        - chr6
+        start:
+        - 17808768
+        - 95257150
+        - 135465814
+    batch-01:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003612242.1
+            exon_number: '2'
+            gene_id: ENSG00000153292.16
+            gene_name: ADGRF1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014795.3
+            havana_transcript: null
+            hgnc_id: HGNC:18990
+            level: '3'
+            protein_id: ENSP00000283297.5
+            tag: basic
+            transcript_id: ENST00000283297.5
+            transcript_name: ADGRF1-201
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        -   ccdsid: null
+            exon_id: null
+            exon_number: null
+            gene_id: ENSG00000248323.9
+            gene_name: LUCAT1
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000162611.16
+            havana_transcript: null
+            hgnc_id: HGNC:48498
+            level: '2'
+            protein_id: null
+            tag: basic
+            transcript_id: ENST00000730025.1
+            transcript_name: LUCAT1-267
+            transcript_support_level: null
+            transcript_type: lncRNA
+        -   ccdsid: null
+            exon_id: null
+            exon_number: null
+            gene_id: ENSG00000304011.1
+            gene_name: ENSG00000304011
+            gene_type: lncRNA
+            havana_gene: null
+            havana_transcript: null
+            hgnc_id: null
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000798830.1
+            transcript_name: ENST00000798830
+            transcript_support_level: null
+            transcript_type: lncRNA
+        end:
+        - 47016768
+        - 91314390
+        - 208245879
+        seqid:
+        - chr6
+        - chr5
+        - chr1
+        start:
+        - 47016617
+        - 91193513
+        - 208244506
+    batch-02:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003729115.1
+            exon_number: '12'
+            gene_id: ENSG00000131044.19
+            gene_name: TTLL9
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000186843.3
+            havana_transcript: OTTHUMT00000473883.1
+            hgnc_id: HGNC:16118
+            level: '2'
+            protein_id: ENSP00000365086.3
+            tag: null
+            transcript_id: ENST00000375921.6
+            transcript_name: TTLL9-202
+            transcript_support_level: '1'
+            transcript_type: nonsense_mediated_decay
+        -   ccdsid: CCDS5467.1
+            exon_id: ENSE00003556589.1
+            exon_number: '1'
+            gene_id: ENSG00000256646.8
+            gene_name: ENSG00000256646
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000168259.1
+            havana_transcript: OTTHUMT00000398997.1
+            hgnc_id: null
+            level: '2'
+            protein_id: ENSP00000455744.1
+            tag: not_organism_supported
+            transcript_id: ENST00000442788.5
+            transcript_name: ENST00000442788
+            transcript_support_level: '5'
+            transcript_type: nonsense_mediated_decay
+        -   ccdsid: null
+            exon_id: ENSE00002791736.1
+            exon_number: '2'
+            gene_id: ENSG00000160439.16
+            gene_name: RDH13
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000180478.4
+            havana_transcript: OTTHUMT00000451484.2
+            hgnc_id: HGNC:19978
+            level: '2'
+            protein_id: null
+            tag: null
+            transcript_id: ENST00000593134.1
+            transcript_name: RDH13-222
+            transcript_support_level: '4'
+            transcript_type: protein_coding_CDS_not_defined
+        end:
+        - 31934888
+        - 42932174
+        - 55064412
+        seqid:
+        - chr20
+        - chr7
+        - chr19
+        start:
+        - 31934692
+        - 42932159
+        - 55063948
+    batch-03:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00004130809.1
+            exon_number: '1'
+            gene_id: ENSG00000226067.8
+            gene_name: LINC00623
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000185016.4
+            havana_transcript: null
+            hgnc_id: HGNC:44252
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000769594.1
+            transcript_name: LINC00623-343
+            transcript_support_level: null
+            transcript_type: lncRNA
+        -   ccdsid: CCDS94631.1
+            exon_id: ENSE00003612797.1
+            exon_number: '5'
+            gene_id: ENSG00000147099.21
+            gene_name: HDAC8
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000021814.18
+            havana_transcript: OTTHUMT00000057204.3
+            hgnc_id: HGNC:13315
+            level: '2'
+            protein_id: ENSP00000362685.2
+            tag: basic
+            transcript_id: ENST00000373583.6
+            transcript_name: HDAC8-208
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        -   ccdsid: CCDS11685.1
+            exon_id: ENSE00001373572.1
+            exon_number: '8'
+            gene_id: ENSG00000154265.16
+            gene_name: ABCA5
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000180303.4
+            havana_transcript: OTTHUMT00000450654.3
+            hgnc_id: HGNC:35
+            level: '2'
+            protein_id: ENSP00000376443.2
+            tag: basic
+            transcript_id: ENST00000392676.8
+            transcript_name: ABCA5-201
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        end:
+        - 120952785
+        - 72495268
+        - 69302906
+        seqid:
+        - chr1
+        - chrX
+        - chr17
+        start:
+        - 120952303
+        - 72495156
+        - 69302718
+    batch-04:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003673013.1
+            exon_number: '19'
+            gene_id: ENSG00000049759.20
+            gene_name: NEDD4L
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000179875.12
+            havana_transcript: OTTHUMT00000448908.1
+            hgnc_id: HGNC:7728
+            level: '2'
+            protein_id: ENSP00000502309.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000674845.1
+            transcript_name: NEDD4L-242
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        -   ccdsid: null
+            exon_id: ENSE00003966028.1
+            exon_number: '5'
+            gene_id: ENSG00000171793.17
+            gene_name: CTPS1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000005712.13
+            havana_transcript: null
+            hgnc_id: HGNC:2519
+            level: '2'
+            protein_id: ENSP00000512402.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000696108.1
+            transcript_name: CTPS1-221
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        -   ccdsid: null
+            exon_id: ENSE00002070419.1
+            exon_number: '1'
+            gene_id: ENSG00000158987.22
+            gene_name: RAPGEF6
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000162683.7
+            havana_transcript: OTTHUMT00000370060.1
+            hgnc_id: HGNC:20655
+            level: '2'
+            protein_id: ENSP00000425772.1
+            tag: null
+            transcript_id: ENST00000515170.5
+            transcript_name: RAPGEF6-214
+            transcript_support_level: '2'
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 58357252
+        - 40988710
+        - 131635213
+        seqid:
+        - chr18
+        - chr1
+        - chr5
+        start:
+        - 58357194
+        - 40988594
+        - 131635031
+    batch-05:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003980557.1
+            exon_number: '7'
+            gene_id: ENSG00000052126.17
+            gene_name: PLEKHA5
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000167921.3
+            havana_transcript: null
+            hgnc_id: HGNC:30036
+            level: '2'
+            protein_id: null
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000706617.1
+            transcript_name: PLEKHA5-236
+            transcript_support_level: null
+            transcript_type: retained_intron
+        -   ccdsid: null
+            exon_id: ENSE00004218036.1
+            exon_number: '1'
+            gene_id: ENSG00000272690.7
+            gene_name: LINC02018
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000185852.36
+            havana_transcript: null
+            hgnc_id: HGNC:52853
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000815791.1
+            transcript_name: LINC02018-313
+            transcript_support_level: null
+            transcript_type: lncRNA
+        -   ccdsid: CCDS43874.1
+            exon_id: ENSE00003692738.1
+            exon_number: '14'
+            gene_id: ENSG00000056586.16
+            gene_name: RC3H2
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000020632.4
+            havana_transcript: OTTHUMT00000053966.1
+            hgnc_id: HGNC:21461
+            level: '2'
+            protein_id: ENSP00000362774.1
+            tag: basic
+            transcript_id: ENST00000373670.5
+            transcript_name: RC3H2-203
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        end:
+        - 19261021
+        - 75435413
+        - 122855397
+        seqid:
+        - chr12
+        - chr3
+        - chr9
+        start:
+        - 19260949
+        - 75435252
+        - 122855184
+    batch-06:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003527710.1
+            exon_number: '8'
+            gene_id: ENSG00000096093.16
+            gene_name: EFHC1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014848.14
+            havana_transcript: OTTHUMT00000489944.1
+            hgnc_id: HGNC:16406
+            level: '2'
+            protein_id: ENSP00000489854.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000637089.1
+            transcript_name: EFHC1-227
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        -   ccdsid: null
+            exon_id: ENSE00002899123.1
+            exon_number: '5'
+            gene_id: ENSG00000072958.9
+            gene_name: AP1M1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000182323.4
+            havana_transcript: OTTHUMT00000460505.1
+            hgnc_id: HGNC:13667
+            level: '2'
+            protein_id: ENSP00000468015.1
+            tag: mRNA_start_NF
+            transcript_id: ENST00000586543.1
+            transcript_name: AP1M1-205
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        end:
+        - 52479250
+        - 16235345
+        seqid:
+        - chr6
+        - chr19
+        start:
+        - 52479037
+        - 16235231
+fields=None, batch_size=1:
+    batch-00:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00000688402.1
+            exon_number: '2'
+            gene_id: ENSG00000137177.20
+            gene_name: KIF13A
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014313.9
+            havana_transcript: OTTHUMT00000039956.2
+            hgnc_id: HGNC:14566
+            level: '2'
+            protein_id: ENSP00000351150.6
+            tag: mRNA_start_NF
+            transcript_id: ENST00000358380.10
+            transcript_name: KIF13A-202
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        end:
+        - 17808930
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr6
+        source:
+        - HAVANA
+        start:
+        - 17808768
+        strand:
+        - '-'
+        type:
+        - exon
+    batch-01:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003554096.1
+            exon_number: '4'
+            gene_id: ENSG00000028203.19
+            gene_name: VEZT
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000170182.4
+            havana_transcript: OTTHUMT00000407816.2
+            hgnc_id: HGNC:18258
+            level: '2'
+            protein_id: ENSP00000380894.4
+            tag: mRNA_end_NF
+            transcript_id: ENST00000397792.8
+            transcript_name: VEZT-202
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        end:
+        - 95257239
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr12
+        source:
+        - HAVANA
+        start:
+        - 95257150
+        strand:
+        - +
+        type:
+        - exon
+    batch-02:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00001350331.1
+            exon_number: '4'
+            gene_id: ENSG00000135541.22
+            gene_name: AHI1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000015631.9
+            havana_transcript: null
+            hgnc_id: HGNC:21575
+            level: '2'
+            protein_id: ENSP00000505809.1
+            tag: alternative_3_UTR
+            transcript_id: ENST00000680840.1
+            transcript_name: AHI1-242
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 135466373
+        frame:
+        - 0
+        score:
+        - null
+        seqid:
+        - chr6
+        source:
+        - HAVANA
+        start:
+        - 135465814
+        strand:
+        - '-'
+        type:
+        - CDS
+    batch-03:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003612242.1
+            exon_number: '2'
+            gene_id: ENSG00000153292.16
+            gene_name: ADGRF1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014795.3
+            havana_transcript: null
+            hgnc_id: HGNC:18990
+            level: '3'
+            protein_id: ENSP00000283297.5
+            tag: basic
+            transcript_id: ENST00000283297.5
+            transcript_name: ADGRF1-201
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        end:
+        - 47016768
+        frame:
+        - 1
+        score:
+        - null
+        seqid:
+        - chr6
+        source:
+        - ENSEMBL
+        start:
+        - 47016617
+        strand:
+        - '-'
+        type:
+        - CDS
+    batch-04:
+        attributes:
+        -   ccdsid: null
+            exon_id: null
+            exon_number: null
+            gene_id: ENSG00000248323.9
+            gene_name: LUCAT1
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000162611.16
+            havana_transcript: null
+            hgnc_id: HGNC:48498
+            level: '2'
+            protein_id: null
+            tag: basic
+            transcript_id: ENST00000730025.1
+            transcript_name: LUCAT1-267
+            transcript_support_level: null
+            transcript_type: lncRNA
+        end:
+        - 91314390
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr5
+        source:
+        - HAVANA
+        start:
+        - 91193513
+        strand:
+        - '-'
+        type:
+        - transcript
+    batch-05:
+        attributes:
+        -   ccdsid: null
+            exon_id: null
+            exon_number: null
+            gene_id: ENSG00000304011.1
+            gene_name: ENSG00000304011
+            gene_type: lncRNA
+            havana_gene: null
+            havana_transcript: null
+            hgnc_id: null
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000798830.1
+            transcript_name: ENST00000798830
+            transcript_support_level: null
+            transcript_type: lncRNA
+        end:
+        - 208245879
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr1
+        source:
+        - HAVANA
+        start:
+        - 208244506
+        strand:
+        - +
+        type:
+        - transcript
+    batch-06:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003729115.1
+            exon_number: '12'
+            gene_id: ENSG00000131044.19
+            gene_name: TTLL9
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000186843.3
+            havana_transcript: OTTHUMT00000473883.1
+            hgnc_id: HGNC:16118
+            level: '2'
+            protein_id: ENSP00000365086.3
+            tag: null
+            transcript_id: ENST00000375921.6
+            transcript_name: TTLL9-202
+            transcript_support_level: '1'
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 31934888
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr20
+        source:
+        - HAVANA
+        start:
+        - 31934692
+        strand:
+        - +
+        type:
+        - exon
+    batch-07:
+        attributes:
+        -   ccdsid: CCDS5467.1
+            exon_id: ENSE00003556589.1
+            exon_number: '1'
+            gene_id: ENSG00000256646.8
+            gene_name: ENSG00000256646
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000168259.1
+            havana_transcript: OTTHUMT00000398997.1
+            hgnc_id: null
+            level: '2'
+            protein_id: ENSP00000455744.1
+            tag: not_organism_supported
+            transcript_id: ENST00000442788.5
+            transcript_name: ENST00000442788
+            transcript_support_level: '5'
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 42932174
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr7
+        source:
+        - HAVANA
+        start:
+        - 42932159
+        strand:
+        - '-'
+        type:
+        - UTR
+    batch-08:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00002791736.1
+            exon_number: '2'
+            gene_id: ENSG00000160439.16
+            gene_name: RDH13
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000180478.4
+            havana_transcript: OTTHUMT00000451484.2
+            hgnc_id: HGNC:19978
+            level: '2'
+            protein_id: null
+            tag: null
+            transcript_id: ENST00000593134.1
+            transcript_name: RDH13-222
+            transcript_support_level: '4'
+            transcript_type: protein_coding_CDS_not_defined
+        end:
+        - 55064412
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr19
+        source:
+        - HAVANA
+        start:
+        - 55063948
+        strand:
+        - '-'
+        type:
+        - exon
+    batch-09:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00004130809.1
+            exon_number: '1'
+            gene_id: ENSG00000226067.8
+            gene_name: LINC00623
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000185016.4
+            havana_transcript: null
+            hgnc_id: HGNC:44252
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000769594.1
+            transcript_name: LINC00623-343
+            transcript_support_level: null
+            transcript_type: lncRNA
+        end:
+        - 120952785
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr1
+        source:
+        - HAVANA
+        start:
+        - 120952303
+        strand:
+        - +
+        type:
+        - exon
+    batch-10:
+        attributes:
+        -   ccdsid: CCDS94631.1
+            exon_id: ENSE00003612797.1
+            exon_number: '5'
+            gene_id: ENSG00000147099.21
+            gene_name: HDAC8
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000021814.18
+            havana_transcript: OTTHUMT00000057204.3
+            hgnc_id: HGNC:13315
+            level: '2'
+            protein_id: ENSP00000362685.2
+            tag: basic
+            transcript_id: ENST00000373583.6
+            transcript_name: HDAC8-208
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        end:
+        - 72495268
+        frame:
+        - 1
+        score:
+        - null
+        seqid:
+        - chrX
+        source:
+        - HAVANA
+        start:
+        - 72495156
+        strand:
+        - '-'
+        type:
+        - CDS
+    batch-11:
+        attributes:
+        -   ccdsid: CCDS11685.1
+            exon_id: ENSE00001373572.1
+            exon_number: '8'
+            gene_id: ENSG00000154265.16
+            gene_name: ABCA5
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000180303.4
+            havana_transcript: OTTHUMT00000450654.3
+            hgnc_id: HGNC:35
+            level: '2'
+            protein_id: ENSP00000376443.2
+            tag: basic
+            transcript_id: ENST00000392676.8
+            transcript_name: ABCA5-201
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        end:
+        - 69302906
+        frame:
+        - 0
+        score:
+        - null
+        seqid:
+        - chr17
+        source:
+        - HAVANA
+        start:
+        - 69302718
+        strand:
+        - '-'
+        type:
+        - CDS
+    batch-12:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003673013.1
+            exon_number: '19'
+            gene_id: ENSG00000049759.20
+            gene_name: NEDD4L
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000179875.12
+            havana_transcript: OTTHUMT00000448908.1
+            hgnc_id: HGNC:7728
+            level: '2'
+            protein_id: ENSP00000502309.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000674845.1
+            transcript_name: NEDD4L-242
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 58357252
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr18
+        source:
+        - HAVANA
+        start:
+        - 58357194
+        strand:
+        - +
+        type:
+        - exon
+    batch-13:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003966028.1
+            exon_number: '5'
+            gene_id: ENSG00000171793.17
+            gene_name: CTPS1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000005712.13
+            havana_transcript: null
+            hgnc_id: HGNC:2519
+            level: '2'
+            protein_id: ENSP00000512402.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000696108.1
+            transcript_name: CTPS1-221
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 40988710
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr1
+        source:
+        - HAVANA
+        start:
+        - 40988594
+        strand:
+        - +
+        type:
+        - exon
+    batch-14:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00002070419.1
+            exon_number: '1'
+            gene_id: ENSG00000158987.22
+            gene_name: RAPGEF6
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000162683.7
+            havana_transcript: OTTHUMT00000370060.1
+            hgnc_id: HGNC:20655
+            level: '2'
+            protein_id: ENSP00000425772.1
+            tag: null
+            transcript_id: ENST00000515170.5
+            transcript_name: RAPGEF6-214
+            transcript_support_level: '2'
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 131635213
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr5
+        source:
+        - HAVANA
+        start:
+        - 131635031
+        strand:
+        - '-'
+        type:
+        - UTR
+    batch-15:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003980557.1
+            exon_number: '7'
+            gene_id: ENSG00000052126.17
+            gene_name: PLEKHA5
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000167921.3
+            havana_transcript: null
+            hgnc_id: HGNC:30036
+            level: '2'
+            protein_id: null
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000706617.1
+            transcript_name: PLEKHA5-236
+            transcript_support_level: null
+            transcript_type: retained_intron
+        end:
+        - 19261021
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr12
+        source:
+        - HAVANA
+        start:
+        - 19260949
+        strand:
+        - +
+        type:
+        - exon
+    batch-16:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00004218036.1
+            exon_number: '1'
+            gene_id: ENSG00000272690.7
+            gene_name: LINC02018
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000185852.36
+            havana_transcript: null
+            hgnc_id: HGNC:52853
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000815791.1
+            transcript_name: LINC02018-313
+            transcript_support_level: null
+            transcript_type: lncRNA
+        end:
+        - 75435413
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr3
+        source:
+        - HAVANA
+        start:
+        - 75435252
+        strand:
+        - +
+        type:
+        - exon
+    batch-17:
+        attributes:
+        -   ccdsid: CCDS43874.1
+            exon_id: ENSE00003692738.1
+            exon_number: '14'
+            gene_id: ENSG00000056586.16
+            gene_name: RC3H2
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000020632.4
+            havana_transcript: OTTHUMT00000053966.1
+            hgnc_id: HGNC:21461
+            level: '2'
+            protein_id: ENSP00000362774.1
+            tag: basic
+            transcript_id: ENST00000373670.5
+            transcript_name: RC3H2-203
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        end:
+        - 122855397
+        frame:
+        - 0
+        score:
+        - null
+        seqid:
+        - chr9
+        source:
+        - HAVANA
+        start:
+        - 122855184
+        strand:
+        - '-'
+        type:
+        - CDS
+    batch-18:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003527710.1
+            exon_number: '8'
+            gene_id: ENSG00000096093.16
+            gene_name: EFHC1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014848.14
+            havana_transcript: OTTHUMT00000489944.1
+            hgnc_id: HGNC:16406
+            level: '2'
+            protein_id: ENSP00000489854.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000637089.1
+            transcript_name: EFHC1-227
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        end:
+        - 52479250
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr6
+        source:
+        - HAVANA
+        start:
+        - 52479037
+        strand:
+        - +
+        type:
+        - exon
+    batch-19:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00002899123.1
+            exon_number: '5'
+            gene_id: ENSG00000072958.9
+            gene_name: AP1M1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000182323.4
+            havana_transcript: OTTHUMT00000460505.1
+            hgnc_id: HGNC:13667
+            level: '2'
+            protein_id: ENSP00000468015.1
+            tag: mRNA_start_NF
+            transcript_id: ENST00000586543.1
+            transcript_name: AP1M1-205
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        end:
+        - 16235345
+        frame:
+        - null
+        score:
+        - null
+        seqid:
+        - chr19
+        source:
+        - HAVANA
+        start:
+        - 16235231
+        strand:
+        - +
+        type:
+        - UTR
+fields=None, batch_size=3:
+    batch-00:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00000688402.1
+            exon_number: '2'
+            gene_id: ENSG00000137177.20
+            gene_name: KIF13A
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014313.9
+            havana_transcript: OTTHUMT00000039956.2
+            hgnc_id: HGNC:14566
+            level: '2'
+            protein_id: ENSP00000351150.6
+            tag: mRNA_start_NF
+            transcript_id: ENST00000358380.10
+            transcript_name: KIF13A-202
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        -   ccdsid: null
+            exon_id: ENSE00003554096.1
+            exon_number: '4'
+            gene_id: ENSG00000028203.19
+            gene_name: VEZT
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000170182.4
+            havana_transcript: OTTHUMT00000407816.2
+            hgnc_id: HGNC:18258
+            level: '2'
+            protein_id: ENSP00000380894.4
+            tag: mRNA_end_NF
+            transcript_id: ENST00000397792.8
+            transcript_name: VEZT-202
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        -   ccdsid: null
+            exon_id: ENSE00001350331.1
+            exon_number: '4'
+            gene_id: ENSG00000135541.22
+            gene_name: AHI1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000015631.9
+            havana_transcript: null
+            hgnc_id: HGNC:21575
+            level: '2'
+            protein_id: ENSP00000505809.1
+            tag: alternative_3_UTR
+            transcript_id: ENST00000680840.1
+            transcript_name: AHI1-242
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 17808930
+        - 95257239
+        - 135466373
+        frame:
+        - null
+        - null
+        - 0
+        score:
+        - null
+        - null
+        - null
+        seqid:
+        - chr6
+        - chr12
+        - chr6
+        source:
+        - HAVANA
+        - HAVANA
+        - HAVANA
+        start:
+        - 17808768
+        - 95257150
+        - 135465814
+        strand:
+        - '-'
+        - +
+        - '-'
+        type:
+        - exon
+        - exon
+        - CDS
+    batch-01:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003612242.1
+            exon_number: '2'
+            gene_id: ENSG00000153292.16
+            gene_name: ADGRF1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014795.3
+            havana_transcript: null
+            hgnc_id: HGNC:18990
+            level: '3'
+            protein_id: ENSP00000283297.5
+            tag: basic
+            transcript_id: ENST00000283297.5
+            transcript_name: ADGRF1-201
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        -   ccdsid: null
+            exon_id: null
+            exon_number: null
+            gene_id: ENSG00000248323.9
+            gene_name: LUCAT1
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000162611.16
+            havana_transcript: null
+            hgnc_id: HGNC:48498
+            level: '2'
+            protein_id: null
+            tag: basic
+            transcript_id: ENST00000730025.1
+            transcript_name: LUCAT1-267
+            transcript_support_level: null
+            transcript_type: lncRNA
+        -   ccdsid: null
+            exon_id: null
+            exon_number: null
+            gene_id: ENSG00000304011.1
+            gene_name: ENSG00000304011
+            gene_type: lncRNA
+            havana_gene: null
+            havana_transcript: null
+            hgnc_id: null
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000798830.1
+            transcript_name: ENST00000798830
+            transcript_support_level: null
+            transcript_type: lncRNA
+        end:
+        - 47016768
+        - 91314390
+        - 208245879
+        frame:
+        - 1
+        - null
+        - null
+        score:
+        - null
+        - null
+        - null
+        seqid:
+        - chr6
+        - chr5
+        - chr1
+        source:
+        - ENSEMBL
+        - HAVANA
+        - HAVANA
+        start:
+        - 47016617
+        - 91193513
+        - 208244506
+        strand:
+        - '-'
+        - '-'
+        - +
+        type:
+        - CDS
+        - transcript
+        - transcript
+    batch-02:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003729115.1
+            exon_number: '12'
+            gene_id: ENSG00000131044.19
+            gene_name: TTLL9
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000186843.3
+            havana_transcript: OTTHUMT00000473883.1
+            hgnc_id: HGNC:16118
+            level: '2'
+            protein_id: ENSP00000365086.3
+            tag: null
+            transcript_id: ENST00000375921.6
+            transcript_name: TTLL9-202
+            transcript_support_level: '1'
+            transcript_type: nonsense_mediated_decay
+        -   ccdsid: CCDS5467.1
+            exon_id: ENSE00003556589.1
+            exon_number: '1'
+            gene_id: ENSG00000256646.8
+            gene_name: ENSG00000256646
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000168259.1
+            havana_transcript: OTTHUMT00000398997.1
+            hgnc_id: null
+            level: '2'
+            protein_id: ENSP00000455744.1
+            tag: not_organism_supported
+            transcript_id: ENST00000442788.5
+            transcript_name: ENST00000442788
+            transcript_support_level: '5'
+            transcript_type: nonsense_mediated_decay
+        -   ccdsid: null
+            exon_id: ENSE00002791736.1
+            exon_number: '2'
+            gene_id: ENSG00000160439.16
+            gene_name: RDH13
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000180478.4
+            havana_transcript: OTTHUMT00000451484.2
+            hgnc_id: HGNC:19978
+            level: '2'
+            protein_id: null
+            tag: null
+            transcript_id: ENST00000593134.1
+            transcript_name: RDH13-222
+            transcript_support_level: '4'
+            transcript_type: protein_coding_CDS_not_defined
+        end:
+        - 31934888
+        - 42932174
+        - 55064412
+        frame:
+        - null
+        - null
+        - null
+        score:
+        - null
+        - null
+        - null
+        seqid:
+        - chr20
+        - chr7
+        - chr19
+        source:
+        - HAVANA
+        - HAVANA
+        - HAVANA
+        start:
+        - 31934692
+        - 42932159
+        - 55063948
+        strand:
+        - +
+        - '-'
+        - '-'
+        type:
+        - exon
+        - UTR
+        - exon
+    batch-03:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00004130809.1
+            exon_number: '1'
+            gene_id: ENSG00000226067.8
+            gene_name: LINC00623
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000185016.4
+            havana_transcript: null
+            hgnc_id: HGNC:44252
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000769594.1
+            transcript_name: LINC00623-343
+            transcript_support_level: null
+            transcript_type: lncRNA
+        -   ccdsid: CCDS94631.1
+            exon_id: ENSE00003612797.1
+            exon_number: '5'
+            gene_id: ENSG00000147099.21
+            gene_name: HDAC8
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000021814.18
+            havana_transcript: OTTHUMT00000057204.3
+            hgnc_id: HGNC:13315
+            level: '2'
+            protein_id: ENSP00000362685.2
+            tag: basic
+            transcript_id: ENST00000373583.6
+            transcript_name: HDAC8-208
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        -   ccdsid: CCDS11685.1
+            exon_id: ENSE00001373572.1
+            exon_number: '8'
+            gene_id: ENSG00000154265.16
+            gene_name: ABCA5
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000180303.4
+            havana_transcript: OTTHUMT00000450654.3
+            hgnc_id: HGNC:35
+            level: '2'
+            protein_id: ENSP00000376443.2
+            tag: basic
+            transcript_id: ENST00000392676.8
+            transcript_name: ABCA5-201
+            transcript_support_level: '1'
+            transcript_type: protein_coding
+        end:
+        - 120952785
+        - 72495268
+        - 69302906
+        frame:
+        - null
+        - 1
+        - 0
+        score:
+        - null
+        - null
+        - null
+        seqid:
+        - chr1
+        - chrX
+        - chr17
+        source:
+        - HAVANA
+        - HAVANA
+        - HAVANA
+        start:
+        - 120952303
+        - 72495156
+        - 69302718
+        strand:
+        - +
+        - '-'
+        - '-'
+        type:
+        - exon
+        - CDS
+        - CDS
+    batch-04:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003673013.1
+            exon_number: '19'
+            gene_id: ENSG00000049759.20
+            gene_name: NEDD4L
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000179875.12
+            havana_transcript: OTTHUMT00000448908.1
+            hgnc_id: HGNC:7728
+            level: '2'
+            protein_id: ENSP00000502309.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000674845.1
+            transcript_name: NEDD4L-242
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        -   ccdsid: null
+            exon_id: ENSE00003966028.1
+            exon_number: '5'
+            gene_id: ENSG00000171793.17
+            gene_name: CTPS1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000005712.13
+            havana_transcript: null
+            hgnc_id: HGNC:2519
+            level: '2'
+            protein_id: ENSP00000512402.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000696108.1
+            transcript_name: CTPS1-221
+            transcript_support_level: null
+            transcript_type: nonsense_mediated_decay
+        -   ccdsid: null
+            exon_id: ENSE00002070419.1
+            exon_number: '1'
+            gene_id: ENSG00000158987.22
+            gene_name: RAPGEF6
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000162683.7
+            havana_transcript: OTTHUMT00000370060.1
+            hgnc_id: HGNC:20655
+            level: '2'
+            protein_id: ENSP00000425772.1
+            tag: null
+            transcript_id: ENST00000515170.5
+            transcript_name: RAPGEF6-214
+            transcript_support_level: '2'
+            transcript_type: nonsense_mediated_decay
+        end:
+        - 58357252
+        - 40988710
+        - 131635213
+        frame:
+        - null
+        - null
+        - null
+        score:
+        - null
+        - null
+        - null
+        seqid:
+        - chr18
+        - chr1
+        - chr5
+        source:
+        - HAVANA
+        - HAVANA
+        - HAVANA
+        start:
+        - 58357194
+        - 40988594
+        - 131635031
+        strand:
+        - +
+        - +
+        - '-'
+        type:
+        - exon
+        - exon
+        - UTR
+    batch-05:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003980557.1
+            exon_number: '7'
+            gene_id: ENSG00000052126.17
+            gene_name: PLEKHA5
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000167921.3
+            havana_transcript: null
+            hgnc_id: HGNC:30036
+            level: '2'
+            protein_id: null
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000706617.1
+            transcript_name: PLEKHA5-236
+            transcript_support_level: null
+            transcript_type: retained_intron
+        -   ccdsid: null
+            exon_id: ENSE00004218036.1
+            exon_number: '1'
+            gene_id: ENSG00000272690.7
+            gene_name: LINC02018
+            gene_type: lncRNA
+            havana_gene: OTTHUMG00000185852.36
+            havana_transcript: null
+            hgnc_id: HGNC:52853
+            level: '2'
+            protein_id: null
+            tag: TAGENE
+            transcript_id: ENST00000815791.1
+            transcript_name: LINC02018-313
+            transcript_support_level: null
+            transcript_type: lncRNA
+        -   ccdsid: CCDS43874.1
+            exon_id: ENSE00003692738.1
+            exon_number: '14'
+            gene_id: ENSG00000056586.16
+            gene_name: RC3H2
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000020632.4
+            havana_transcript: OTTHUMT00000053966.1
+            hgnc_id: HGNC:21461
+            level: '2'
+            protein_id: ENSP00000362774.1
+            tag: basic
+            transcript_id: ENST00000373670.5
+            transcript_name: RC3H2-203
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        end:
+        - 19261021
+        - 75435413
+        - 122855397
+        frame:
+        - null
+        - null
+        - 0
+        score:
+        - null
+        - null
+        - null
+        seqid:
+        - chr12
+        - chr3
+        - chr9
+        source:
+        - HAVANA
+        - HAVANA
+        - HAVANA
+        start:
+        - 19260949
+        - 75435252
+        - 122855184
+        strand:
+        - +
+        - +
+        - '-'
+        type:
+        - exon
+        - exon
+        - CDS
+    batch-06:
+        attributes:
+        -   ccdsid: null
+            exon_id: ENSE00003527710.1
+            exon_number: '8'
+            gene_id: ENSG00000096093.16
+            gene_name: EFHC1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000014848.14
+            havana_transcript: OTTHUMT00000489944.1
+            hgnc_id: HGNC:16406
+            level: '2'
+            protein_id: ENSP00000489854.1
+            tag: RNA_Seq_supported_only
+            transcript_id: ENST00000637089.1
+            transcript_name: EFHC1-227
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        -   ccdsid: null
+            exon_id: ENSE00002899123.1
+            exon_number: '5'
+            gene_id: ENSG00000072958.9
+            gene_name: AP1M1
+            gene_type: protein_coding
+            havana_gene: OTTHUMG00000182323.4
+            havana_transcript: OTTHUMT00000460505.1
+            hgnc_id: HGNC:13667
+            level: '2'
+            protein_id: ENSP00000468015.1
+            tag: mRNA_start_NF
+            transcript_id: ENST00000586543.1
+            transcript_name: AP1M1-205
+            transcript_support_level: '5'
+            transcript_type: protein_coding
+        end:
+        - 52479250
+        - 16235345
+        frame:
+        - null
+        - null
+        score:
+        - null
+        - null
+        seqid:
+        - chr6
+        - chr19
+        source:
+        - HAVANA
+        - HAVANA
+        start:
+        - 52479037
+        - 16235231
+        strand:
+        - +
+        - +
+        type:
+        - exon
+        - UTR

--- a/py-oxbow/tests/manifests/test_function.TestGtfFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_function.TestGtfFile.test_select_callstack.yaml
@@ -26,7 +26,7 @@ GtfFile("data/malformed.gtf").select(): |-
         ->  oxbow._core.function.GxfFile._scanner_kwargs
         <-  {'compressed': 'False'}
         ->  oxbow._core.function.GxfFile._schema_kwargs
-        <-  {'fields': 'None'}
+        <-  {'fields': 'None', 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
         ->  oxbow._core.function.GxfFile.__init__("data/malformed.gtf", None, attribute_defs=[("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), ("protein_id", "String"), ("tag", "String"), ("transcript_id", "String"), ("transcript_name", "String"), ("transcript_support_level", "String"), ("transcript_type", "String")], fields=None, compressed=False)
             ->  oxbow._core.base.DataFile.__init__("data/malformed.gtf", None, None)
             <-  None
@@ -52,7 +52,7 @@ GtfFile("data/malformed.gtf").select(): |-
                             <-  {'compressed': 'False'}
                         <-  builtins.PyGtfScanner.<object>
                         ->  oxbow._core.function.GxfFile._schema_kwargs
-                        <-  {'fields': 'None'}
+                        <-  {'fields': 'None', 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
                     <-  seqid: string
                         source: string
                         type: string
@@ -61,6 +61,23 @@ GtfFile("data/malformed.gtf").select(): |-
                         score: float
                         strand: string
                         frame: uint8
+                        attributes: struct<ccdsid: string, exon_id: string, exon_number: string, gene_id: string, gene_name: string, gene_type: string, havana_gene: string, havana_transcript: string, hgnc_id: string, level: string, protein_id: string, tag: string, transcript_id: string, transcript_name: string, transcript_support_level: string, transcript_type: string>
+                          child 0, ccdsid: string
+                          child 1, exon_id: string
+                          child 2, exon_number: string
+                          child 3, gene_id: string
+                          child 4, gene_name: string
+                          child 5, gene_type: string
+                          child 6, havana_gene: string
+                          child 7, havana_transcript: string
+                          child 8, hgnc_id: string
+                          child 9, level: string
+                          child 10, protein_id: string
+                          child 11, tag: string
+                          child 12, transcript_id: string
+                          child 13, transcript_name: string
+                          child 14, transcript_support_level: string
+                          child 15, transcript_type: string
                 <-  oxbow._core.function.GxfFile._batch_readers.<locals>.<lambda>
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
@@ -82,7 +99,7 @@ GtfFile("data/sample.gtf").select(): |-
         ->  oxbow._core.function.GxfFile._scanner_kwargs
         <-  {'compressed': 'False'}
         ->  oxbow._core.function.GxfFile._schema_kwargs
-        <-  {'fields': 'None'}
+        <-  {'fields': 'None', 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
         ->  oxbow._core.function.GxfFile.__init__("data/sample.gtf", None, attribute_defs=[("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), ("protein_id", "String"), ("tag", "String"), ("transcript_id", "String"), ("transcript_name", "String"), ("transcript_support_level", "String"), ("transcript_type", "String")], fields=None, compressed=False)
             ->  oxbow._core.base.DataFile.__init__("data/sample.gtf", None, None)
             <-  None
@@ -108,7 +125,7 @@ GtfFile("data/sample.gtf").select(): |-
                             <-  {'compressed': 'False'}
                         <-  builtins.PyGtfScanner.<object>
                         ->  oxbow._core.function.GxfFile._schema_kwargs
-                        <-  {'fields': 'None'}
+                        <-  {'fields': 'None', 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
                     <-  seqid: string
                         source: string
                         type: string
@@ -117,6 +134,23 @@ GtfFile("data/sample.gtf").select(): |-
                         score: float
                         strand: string
                         frame: uint8
+                        attributes: struct<ccdsid: string, exon_id: string, exon_number: string, gene_id: string, gene_name: string, gene_type: string, havana_gene: string, havana_transcript: string, hgnc_id: string, level: string, protein_id: string, tag: string, transcript_id: string, transcript_name: string, transcript_support_level: string, transcript_type: string>
+                          child 0, ccdsid: string
+                          child 1, exon_id: string
+                          child 2, exon_number: string
+                          child 3, gene_id: string
+                          child 4, gene_name: string
+                          child 5, gene_type: string
+                          child 6, havana_gene: string
+                          child 7, havana_transcript: string
+                          child 8, hgnc_id: string
+                          child 9, level: string
+                          child 10, protein_id: string
+                          child 11, tag: string
+                          child 12, transcript_id: string
+                          child 13, transcript_name: string
+                          child 14, transcript_support_level: string
+                          child 15, transcript_type: string
                 <-  oxbow._core.function.GxfFile._batch_readers.<locals>.<lambda>
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_oxbow.TestPyGtfScanner.test_schema.yaml
+++ b/py-oxbow/tests/manifests/test_oxbow.TestPyGtfScanner.test_schema.yaml
@@ -1,0 +1,13 @@
+schema():
+- seqid
+- source
+- type
+- start
+- end
+- score
+- strand
+- frame
+schema(fields=("seqid", "start", "end")):
+- seqid
+- start
+- end

--- a/py-oxbow/tests/test_function.py
+++ b/py-oxbow/tests/test_function.py
@@ -464,3 +464,26 @@ class TestGtfFile:
             actual = str(e)
 
         assert manifest[f"fields={fields}, batch_size={batch_size}"] == actual
+
+    @pytest.mark.parametrize(
+        ("fields", "batch_size"),
+        [
+            (None, 1),
+            (None, 3),
+            (None, None),
+            (("seqid", "start", "end"), 3),
+            (("nonexistent-field",), 3),
+        ],
+    )
+    def test_select(self, fields, batch_size, manifest: Manifest):
+        batches = (
+            ox.GtfFile("data/sample.gtf", fields=fields)
+            .select()
+            .to_batches(batch_size=batch_size)
+        )
+        try:
+            actual = {f"batch-{i:02}": b.to_pydict() for i, b in enumerate(batches)}
+        except ValueError as e:
+            actual = str(e)
+
+        assert manifest[f"fields={fields}, batch_size={batch_size}"] == actual

--- a/py-oxbow/tests/test_function.py
+++ b/py-oxbow/tests/test_function.py
@@ -470,20 +470,19 @@ class TestGtfFile:
         [
             (None, 1),
             (None, 3),
-            (None, None),
             (("seqid", "start", "end"), 3),
             (("nonexistent-field",), 3),
         ],
     )
     def test_select(self, fields, batch_size, manifest: Manifest):
-        batches = (
-            ox.GtfFile("data/sample.gtf", fields=fields)
-            .select()
-            .to_batches(batch_size=batch_size)
-        )
         try:
+            batches = (
+                ox.GtfFile("data/sample.gtf", fields=fields)
+                .select()
+                .to_batches(batch_size=batch_size)
+            )
             actual = {f"batch-{i:02}": b.to_pydict() for i, b in enumerate(batches)}
-        except ValueError as e:
+        except OSError as e:
             actual = str(e)
 
         assert manifest[f"fields={fields}, batch_size={batch_size}"] == actual

--- a/py-oxbow/tests/test_oxbow.py
+++ b/py-oxbow/tests/test_oxbow.py
@@ -632,3 +632,15 @@ class TestPyGtfScanner:
             result = str(e)
             pass
         assert manifest[str(input)] == result
+
+    @pytest.mark.parametrize(
+        "input",
+        [
+            Input(),
+            Input(fields=("seqid", "start", "end")),
+        ],
+    )
+    def test_schema(self, input, manifest: pytest_manifest.Manifest):
+        scanner = ox.PyGtfScanner("data/sample.gtf")
+        schema = scanner.schema(**input.kwargs)
+        assert manifest[f"schema({str(input)})"] == schema.names


### PR DESCRIPTION
This pull request fixes a bug in `GxfFile`-based classes (`GffFile` and `GtfFile`). The changes ensure that `attribute_defs` are included in the Arrow schema so that the output includes that information.

### Core Enhancements to Schema Handling:

* [`py-oxbow/oxbow/_core/function.py`](diffhunk://#diff-a7485b3cf5033503ee4167f509c2658390936b89e80a8e9f0e694bba52a0b6a9L248-R253): Updated the `__init__` method of `GxfFile` to include `attribute_defs` in `__schema_kwargs`.