### PR TITLE
Fixed bug in `_batch_readers` closures

### DIFF
--- a/py-oxbow/oxbow/_core/alignment.py
+++ b/py-oxbow/oxbow/_core/alignment.py
@@ -81,7 +81,7 @@ class AlignmentFile(DataSource):
                         **self._scan_kwargs,
                     )
                 yield self._make_batch_reader(stream)
-                
+
         else:
             stream = partial(
                 self._scanner.scan,

--- a/py-oxbow/oxbow/_core/alignment.py
+++ b/py-oxbow/oxbow/_core/alignment.py
@@ -80,19 +80,14 @@ class AlignmentFile(DataSource):
                         index=self._index,
                         **self._scan_kwargs,
                     )
-                yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                    data=stream(fields=fields, batch_size=batch_size),
-                    schema=self.schema,
-                )
+                yield self._make_batch_reader(stream)
+                
         else:
             stream = partial(
                 self._scanner.scan,
                 **self._scan_kwargs,
             )
-            yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                data=stream(fields=fields, batch_size=batch_size),
-                schema=self.schema,
-            )
+            yield self._make_batch_reader(stream)
 
     def __init__(
         self,

--- a/py-oxbow/oxbow/_core/base.py
+++ b/py-oxbow/oxbow/_core/base.py
@@ -49,6 +49,14 @@ class DataSource(metaclass=DataSourceMeta):
         self,
     ) -> Iterable[Callable[[list[str] | None, int], pa.RecordBatchReader]]: ...
 
+    def _make_batch_reader(self, stream):
+        def _batch_reader(fields, batch_size):
+            return pa.RecordBatchReader.from_stream(
+                data=stream(fields=fields, batch_size=batch_size),
+                schema=self.schema,
+            )
+        return _batch_reader
+
     def __init_subclass__(cls, file_type: FileType | None = None) -> None:
         if file_type:
             assert file_type not in cls._registry

--- a/py-oxbow/oxbow/_core/base.py
+++ b/py-oxbow/oxbow/_core/base.py
@@ -55,6 +55,7 @@ class DataSource(metaclass=DataSourceMeta):
                 data=stream(fields=fields, batch_size=batch_size),
                 schema=self.schema,
             )
+
         return _batch_reader
 
     def __init_subclass__(cls, file_type: FileType | None = None) -> None:

--- a/py-oxbow/oxbow/_core/feature.py
+++ b/py-oxbow/oxbow/_core/feature.py
@@ -115,16 +115,10 @@ class BbiFile(FeatureFile):
         if self._regions:
             for region in self._regions:
                 stream = partial(self._scanner.scan_query, region=region)
-                yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                    data=stream(fields=fields, batch_size=batch_size),
-                    schema=self.schema,
-                )
+                yield self._make_batch_reader(stream)
         else:
             stream = self._scanner.scan
-            yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                data=stream(fields=fields, batch_size=batch_size),
-                schema=self.schema,
-            )
+            yield self._make_batch_reader(stream)
 
     @property
     def _scanner(
@@ -259,16 +253,10 @@ class BedFile(FeatureFile, file_type=FileType.BED):
                 stream = partial(
                     self._scanner.scan_query, region=region, index=self._index
                 )
-                yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                    data=stream(fields=fields, batch_size=batch_size),
-                    schema=self.schema,
-                )
+                yield self._make_batch_reader(stream)
         else:
             stream = self._scanner.scan
-            yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                data=stream(fields=fields, batch_size=batch_size),
-                schema=self.schema,
-            )
+            yield self._make_batch_reader(stream)
 
     def __init__(
         self,
@@ -329,19 +317,13 @@ class GxfFile(FeatureFile):
                     index=self._index,
                     **self._scan_kwargs,
                 )
-                yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                    data=stream(fields=fields, batch_size=batch_size),
-                    schema=self.schema,
-                )
+                yield self._make_batch_reader(stream)
         else:
             stream = partial(
                 self._scanner.scan,
                 **self._scan_kwargs,
             )
-            yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                data=stream(fields=fields, batch_size=batch_size),
-                schema=self.schema,
-            )
+            yield self._make_batch_reader(stream)
 
     def __init__(
         self,

--- a/py-oxbow/oxbow/_core/feature.py
+++ b/py-oxbow/oxbow/_core/feature.py
@@ -37,7 +37,7 @@ from_gtf(uri, opener, fields, index, compressed, regions, attribute_defs, attrib
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Generator
+from typing import TYPE_CHECKING, Any, Callable, Generator, cast
 
 import pyarrow as pa
 
@@ -124,8 +124,7 @@ class BbiFile(FeatureFile):
     def _scanner(
         self,
     ) -> PyBigBedScanner | PyBigWigScanner | PyBBIZoomScanner:
-        scanner = super()._scanner
-        assert isinstance(scanner, (PyBigBedScanner, PyBigWigScanner))
+        scanner = cast(PyBigBedScanner | PyBigWigScanner, super()._scanner)
         if self._resolution:
             return scanner.get_zoom(self._resolution)
         else:

--- a/py-oxbow/oxbow/_core/sequence.py
+++ b/py-oxbow/oxbow/_core/sequence.py
@@ -120,16 +120,10 @@ class FastaFile(SequenceFile, file_type=FileType.FASTA):
                 index=self._index,
                 gzi=self._gzi,
             )
-            yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                data=stream(fields=fields, batch_size=batch_size),
-                schema=self.schema,
-            )
+            yield self._make_batch_reader(stream)
         else:
             stream = self._scanner.scan
-            yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                data=stream(fields=fields, batch_size=batch_size),
-                schema=self.schema,
-            )
+            yield self._make_batch_reader(stream)
 
     def __init__(
         self,
@@ -189,10 +183,7 @@ class FastqFile(SequenceFile, file_type=FileType.FASTQ):
         self,
     ) -> Generator[Callable[[list[str] | None, int], pa.RecordBatchReader]]:
         stream = self._scanner.scan
-        yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-            data=stream(fields=fields, batch_size=batch_size),
-            schema=self.schema,
-        )
+        yield self._make_batch_reader(stream)
 
 
 def from_fasta(

--- a/py-oxbow/oxbow/_core/variant.py
+++ b/py-oxbow/oxbow/_core/variant.py
@@ -73,16 +73,10 @@ class VariantFile(DataSource):
                     index=self._index,
                     **self._scan_kwargs,
                 )
-                yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                    data=stream(fields=fields, batch_size=batch_size),
-                    schema=self.schema,
-                )
+                yield self._make_batch_reader(stream)
         else:
             stream = partial(self._scanner.scan, **self._scan_kwargs)
-            yield lambda fields, batch_size: pa.RecordBatchReader.from_stream(
-                data=stream(fields=fields, batch_size=batch_size),
-                schema=self.schema,
-            )
+            yield self._make_batch_reader(stream)
 
     def __init__(
         self,

--- a/py-oxbow/tests/manifests/test_alignment.TestBamFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_alignment.TestBamFile.test_batches_callstack.yaml
@@ -5,22 +5,24 @@ BamFile("data/sample.bam", fields=('qname', 'rname', 'mapq')).batches(batch_size
     <-  AlignmentFile._batch_readers.<generator>
     ->  oxbow._core.base.DataSource._scanner
         ->  oxbow._core.base.DataSource._source
-        <-  'data/sample.bam'
+        <-  data/sample.bam
         ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
         <-  {'compressed': 'True'}
     <-  oxbow.core.PyBamScanner.<object>
     ->  oxbow._core.alignment.AlignmentFile._scan_kwargs
-    <-  {'fields': ("'qname'", "'rname'", "'mapq'"), 'tag_defs': [("'XX'", "'BS'")]}
+    <-  {'fields': ('qname', 'rname', 'mapq'), 'tag_defs': [('XX', 'BS')]}
+    ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyBamScanner.scan, fields=("qname", "rname", "mapq"), tag_defs=[("XX", "BS")])>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.alignment.AlignmentFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bam'
+                <-  data/sample.bam
                 ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                 <-  {'compressed': 'True'}
             <-  oxbow.core.PyBamScanner.<object>
             ->  oxbow._core.alignment.AlignmentFile._schema_kwargs
-            <-  {'fields': ("'qname'", "'rname'", "'mapq'"), 'tag_defs': [("'XX'", "'BS'")]}
+            <-  {'fields': ('qname', 'rname', 'mapq'), 'tag_defs': [('XX', 'BS')]}
         <-  qname: string
             rname: dictionary<values=string, indices=int32, ordered=0>
             mapq: uint8
@@ -44,4 +46,4 @@ BamFile("data/sample.bam", fields=('qname', 'rname', 'mapq')).batches(batch_size
             tags: -- is_valid: all not null
             -- child 0 type: list<item: uint16>
             [[12561,2,20,112],null,null]
-    <-  oxbow._core.alignment.AlignmentFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_alignment.TestBamFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_alignment.TestBamFile.test_fragments_callstack.yaml
@@ -4,27 +4,29 @@ BamFile("data/sample.bam", fields=('qname', 'rname', 'mapq')).batches(batch_size
         <-  AlignmentFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.bam'
+            <-  data/sample.bam
             ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
             <-  {'compressed': 'True'}
         <-  oxbow.core.PyBamScanner.<object>
         ->  oxbow._core.alignment.AlignmentFile._scan_kwargs
-        <-  {'fields': ("'qname'", "'rname'", "'mapq'"), 'tag_defs': [("'XX'", "'BS'")]}
+        <-  {'fields': ('qname', 'rname', 'mapq'), 'tag_defs': [('XX', 'BS')]}
+        ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyBamScanner.scan, fields=("qname", "rname", "mapq"), tag_defs=[("XX", "BS")])>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.alignment.AlignmentFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bam'
+                    <-  data/sample.bam
                     ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                     <-  {'compressed': 'True'}
                 <-  oxbow.core.PyBamScanner.<object>
                 ->  oxbow._core.alignment.AlignmentFile._schema_kwargs
-                <-  {'fields': ("'qname'", "'rname'", "'mapq'"), 'tag_defs': [("'XX'", "'BS'")]}
+                <-  {'fields': ('qname', 'rname', 'mapq'), 'tag_defs': [('XX', 'BS')]}
             <-  qname: string
                 rname: dictionary<values=string, indices=int32, ordered=0>
                 mapq: uint8
                 tags: struct<XX: list<item: uint16>>
                   child 0, XX: list<item: uint16>
                       child 0, item: uint16
-        <-  oxbow._core.alignment.AlignmentFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_alignment.TestBamFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_alignment.TestBamFile.test_init_callstack.yaml
@@ -1,37 +1,37 @@
 BamFile("data/does-not-exist.bam"): |-
-    ->  oxbow._core.alignment.BamFile.__init__("data/does-not-exist.bam")
-        ->  oxbow._core.alignment.AlignmentFile.__init__("data/does-not-exist.bam", compressed=True)
-            ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bam", None, None)
+    ->  oxbow._core.alignment.BamFile.__init__(data/does-not-exist.bam)
+        ->  oxbow._core.alignment.AlignmentFile.__init__(data/does-not-exist.bam, compressed=True)
+            ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bam, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/does-not-exist.bam'
+                <-  data/does-not-exist.bam
                 ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                 <-  {'compressed': 'True'}
             !!  PanicException('called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }')
         !!  PanicException("called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: 'No such file or directory' }")
     !!  PanicException("called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: 'No such file or directory' }")
 BamFile("data/malformed.bam"): |-
-    ->  oxbow._core.alignment.BamFile.__init__("data/malformed.bam")
-        ->  oxbow._core.alignment.AlignmentFile.__init__("data/malformed.bam", compressed=True)
-            ->  oxbow._core.base.DataSource.__init__("data/malformed.bam", None, None)
+    ->  oxbow._core.alignment.BamFile.__init__(data/malformed.bam)
+        ->  oxbow._core.alignment.AlignmentFile.__init__(data/malformed.bam, compressed=True)
+            ->  oxbow._core.base.DataSource.__init__(data/malformed.bam, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/malformed.bam'
+                <-  data/malformed.bam
                 ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                 <-  {'compressed': 'True'}
             !!  PanicException('called `Result::unwrap()` on an `Err` value: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }')
         !!  PanicException("called `Result::unwrap()` on an `Err` value: Error { kind: UnexpectedEof, message: 'failed to fill whole buffer' }")
     !!  PanicException("called `Result::unwrap()` on an `Err` value: Error { kind: UnexpectedEof, message: 'failed to fill whole buffer' }")
 BamFile("data/sample.bam"): |-
-    ->  oxbow._core.alignment.BamFile.__init__("data/sample.bam")
-        ->  oxbow._core.alignment.AlignmentFile.__init__("data/sample.bam", compressed=True)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.bam", None, None)
+    ->  oxbow._core.alignment.BamFile.__init__(data/sample.bam)
+        ->  oxbow._core.alignment.AlignmentFile.__init__(data/sample.bam, compressed=True)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.bam, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bam'
+                <-  data/sample.bam
                 ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                 <-  {'compressed': 'True'}
             <-  oxbow.core.PyBamScanner.<object>

--- a/py-oxbow/tests/manifests/test_alignment.TestBamFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_alignment.TestBamFile.test_select_callstack.yaml
@@ -1,14 +1,14 @@
 BamFile(data/sample.bam).select(): |-
     ->  oxbow._core.base.DataSource.select()
         ->  oxbow._core.alignment.AlignmentFile._scan_kwargs
-        <-  {'fields': 'None', 'tag_defs': [("'XX'", "'BS'")]}
+        <-  {'fields': 'None', 'tag_defs': [('XX', 'BS')]}
         ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
         <-  {'compressed': 'True'}
         ->  oxbow._core.alignment.AlignmentFile._schema_kwargs
-        <-  {'fields': 'None', 'tag_defs': [("'XX'", "'BS'")]}
-        ->  oxbow._core.alignment.BamFile.__init__("data/sample.bam", None, fields=None, tag_defs=[("XX", "BS")], compressed=True)
-            ->  oxbow._core.alignment.AlignmentFile.__init__("data/sample.bam", None, compressed=True, fields=None, tag_defs=[("XX", "BS")])
-                ->  oxbow._core.base.DataSource.__init__("data/sample.bam", None, None)
+        <-  {'fields': 'None', 'tag_defs': [('XX', 'BS')]}
+        ->  oxbow._core.alignment.BamFile.__init__(data/sample.bam, None, fields=None, tag_defs=[('XX', 'BS')], compressed=True)
+            ->  oxbow._core.alignment.AlignmentFile.__init__(data/sample.bam, None, compressed=True, fields=None, tag_defs=[('XX', 'BS')])
+                ->  oxbow._core.base.DataSource.__init__(data/sample.bam, None, None)
                 <-  None
             <-  None
         <-  None
@@ -18,22 +18,24 @@ BamFile(data/sample.bam).select(): |-
                 <-  AlignmentFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bam'
+                    <-  data/sample.bam
                     ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                     <-  {'compressed': 'True'}
                 <-  oxbow.core.PyBamScanner.<object>
                 ->  oxbow._core.alignment.AlignmentFile._scan_kwargs
-                <-  {'fields': 'None', 'tag_defs': [("'XX'", "'BS'")]}
+                <-  {'fields': 'None', 'tag_defs': [('XX', 'BS')]}
+                ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyBamScanner.scan, fields=None, tag_defs=[("XX", "BS")])>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.alignment.AlignmentFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.bam'
+                            <-  data/sample.bam
                             ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                             <-  {'compressed': 'True'}
                         <-  oxbow.core.PyBamScanner.<object>
                         ->  oxbow._core.alignment.AlignmentFile._schema_kwargs
-                        <-  {'fields': 'None', 'tag_defs': [("'XX'", "'BS'")]}
+                        <-  {'fields': 'None', 'tag_defs': [('XX', 'BS')]}
                     <-  qname: string
                         flag: uint16
                         rname: dictionary<values=string, indices=int32, ordered=0>
@@ -49,7 +51,7 @@ BamFile(data/sample.bam).select(): |-
                         tags: struct<XX: list<item: uint16>>
                           child 0, XX: list<item: uint16>
                               child 0, item: uint16
-                <-  oxbow._core.alignment.AlignmentFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_alignment.TestSamFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_alignment.TestSamFile.test_batches_callstack.yaml
@@ -5,22 +5,24 @@ SamFile("data/sample.sam", fields=('qname', 'rname', 'mapq')).batches(batch_size
     <-  AlignmentFile._batch_readers.<generator>
     ->  oxbow._core.base.DataSource._scanner
         ->  oxbow._core.base.DataSource._source
-        <-  'data/sample.sam'
+        <-  data/sample.sam
         ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
         <-  {'compressed': 'False'}
     <-  oxbow.core.PySamScanner.<object>
     ->  oxbow._core.alignment.AlignmentFile._scan_kwargs
-    <-  {'fields': ("'qname'", "'rname'", "'mapq'"), 'tag_defs': []}
+    <-  {'fields': ('qname', 'rname', 'mapq'), 'tag_defs': []}
+    ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PySamScanner.scan, fields=("qname", "rname", "mapq"), tag_defs=[])>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.alignment.AlignmentFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.sam'
+                <-  data/sample.sam
                 ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                 <-  {'compressed': 'False'}
             <-  oxbow.core.PySamScanner.<object>
             ->  oxbow._core.alignment.AlignmentFile._schema_kwargs
-            <-  {'fields': ("'qname'", "'rname'", "'mapq'"), 'tag_defs': []}
+            <-  {'fields': ('qname', 'rname', 'mapq'), 'tag_defs': []}
         <-  qname: string
             rname: dictionary<values=string, indices=int32, ordered=0>
             mapq: uint8
@@ -35,4 +37,4 @@ SamFile("data/sample.sam", fields=('qname', 'rname', 'mapq')).batches(batch_size
             ["chr1","chr2"]-- indices:
             [0,0,0]
             mapq: [30,30,30]
-    <-  oxbow._core.alignment.AlignmentFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_alignment.TestSamFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_alignment.TestSamFile.test_fragments_callstack.yaml
@@ -4,24 +4,26 @@ SamFile("data/sample.sam", fields=('qname', 'rname', 'mapq')).batches(batch_size
         <-  AlignmentFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.sam'
+            <-  data/sample.sam
             ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PySamScanner.<object>
         ->  oxbow._core.alignment.AlignmentFile._scan_kwargs
-        <-  {'fields': ("'qname'", "'rname'", "'mapq'"), 'tag_defs': []}
+        <-  {'fields': ('qname', 'rname', 'mapq'), 'tag_defs': []}
+        ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PySamScanner.scan, fields=("qname", "rname", "mapq"), tag_defs=[])>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.alignment.AlignmentFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.sam'
+                    <-  data/sample.sam
                     ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  oxbow.core.PySamScanner.<object>
                 ->  oxbow._core.alignment.AlignmentFile._schema_kwargs
-                <-  {'fields': ("'qname'", "'rname'", "'mapq'"), 'tag_defs': []}
+                <-  {'fields': ('qname', 'rname', 'mapq'), 'tag_defs': []}
             <-  qname: string
                 rname: dictionary<values=string, indices=int32, ordered=0>
                 mapq: uint8
-        <-  oxbow._core.alignment.AlignmentFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_alignment.TestSamFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_alignment.TestSamFile.test_init_callstack.yaml
@@ -1,32 +1,32 @@
 SamFile("data/does-not-exist.sam"): |-
-    ->  oxbow._core.alignment.AlignmentFile.__init__("data/does-not-exist.sam")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.sam", None, None)
+    ->  oxbow._core.alignment.AlignmentFile.__init__(data/does-not-exist.sam)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.sam, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/does-not-exist.sam'
+            <-  data/does-not-exist.sam
             ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  FileNotFoundError('No such file or directory (os error 2)')
     !!  FileNotFoundError("No such file or directory (os error 2)")
 SamFile("data/malformed.sam"): |-
-    ->  oxbow._core.alignment.AlignmentFile.__init__("data/malformed.sam")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.sam", None, None)
+    ->  oxbow._core.alignment.AlignmentFile.__init__(data/malformed.sam)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.sam, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/malformed.sam'
+            <-  data/malformed.sam
             ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PySamScanner.<object>
     <-  None
 SamFile("data/sample.sam"): |-
-    ->  oxbow._core.alignment.AlignmentFile.__init__("data/sample.sam")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.sam", None, None)
+    ->  oxbow._core.alignment.AlignmentFile.__init__(data/sample.sam)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.sam, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.sam'
+            <-  data/sample.sam
             ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PySamScanner.<object>

--- a/py-oxbow/tests/manifests/test_alignment.TestSamFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_alignment.TestSamFile.test_select_callstack.yaml
@@ -6,8 +6,8 @@ SamFile(data/sample.sam).select(): |-
         <-  {'compressed': 'False'}
         ->  oxbow._core.alignment.AlignmentFile._schema_kwargs
         <-  {'fields': 'None', 'tag_defs': []}
-        ->  oxbow._core.alignment.AlignmentFile.__init__("data/sample.sam", None, fields=None, tag_defs=[], compressed=False)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.sam", None, None)
+        ->  oxbow._core.alignment.AlignmentFile.__init__(data/sample.sam, None, fields=None, tag_defs=[], compressed=False)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.sam, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -16,17 +16,19 @@ SamFile(data/sample.sam).select(): |-
                 <-  AlignmentFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.sam'
+                    <-  data/sample.sam
                     ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  oxbow.core.PySamScanner.<object>
                 ->  oxbow._core.alignment.AlignmentFile._scan_kwargs
                 <-  {'fields': 'None', 'tag_defs': []}
+                ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PySamScanner.scan, fields=None, tag_defs=[])>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.alignment.AlignmentFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.sam'
+                            <-  data/sample.sam
                             ->  oxbow._core.alignment.AlignmentFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         <-  oxbow.core.PySamScanner.<object>
@@ -44,7 +46,7 @@ SamFile(data/sample.sam).select(): |-
                         seq: string
                         qual: string
                         end: int32
-                <-  oxbow._core.alignment.AlignmentFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_feature.TestBedFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBedFile.test_batches_callstack.yaml
@@ -5,20 +5,22 @@ BedFile("data/sample.bed", fields=('chrom', 'start', 'end')).batches(batch_size=
     <-  BedFile._batch_readers.<generator>
     ->  oxbow._core.base.DataSource._scanner
         ->  oxbow._core.base.DataSource._source
-        <-  'data/sample.bed'
+        <-  data/sample.bed
         ->  oxbow._core.feature.BedFile._scanner_kwargs
-        <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+        <-  {'bed_schema': 'bed3', 'compressed': 'False'}
     <-  builtins.PyBedScanner.<object>
+    ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.feature.BedFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bed'
+                <-  data/sample.bed
                 ->  oxbow._core.feature.BedFile._scanner_kwargs
-                <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+                <-  {'bed_schema': 'bed3', 'compressed': 'False'}
             <-  builtins.PyBedScanner.<object>
             ->  oxbow._core.feature.BedFile._schema_kwargs
-            <-  {'fields': ("'chrom'", "'start'", "'end'")}
+            <-  {'fields': ('chrom', 'start', 'end')}
         <-  chrom: string
             start: int64
             end: int64
@@ -148,4 +150,4 @@ BedFile("data/sample.bed", fields=('chrom', 'start', 'end')).batches(batch_size=
             chrom: ["chr9"]
             start: [500001]
             end: [750000]
-    <-  oxbow._core.feature.BedFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_feature.TestBedFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBedFile.test_fragments_callstack.yaml
@@ -4,22 +4,24 @@ BedFile("data/sample.bed", fields=('chrom', 'start', 'end')).batches(batch_size=
         <-  BedFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.bed'
+            <-  data/sample.bed
             ->  oxbow._core.feature.BedFile._scanner_kwargs
-            <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+            <-  {'bed_schema': 'bed3', 'compressed': 'False'}
         <-  builtins.PyBedScanner.<object>
+        ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.feature.BedFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bed'
+                    <-  data/sample.bed
                     ->  oxbow._core.feature.BedFile._scanner_kwargs
-                    <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+                    <-  {'bed_schema': 'bed3', 'compressed': 'False'}
                 <-  builtins.PyBedScanner.<object>
                 ->  oxbow._core.feature.BedFile._schema_kwargs
-                <-  {'fields': ("'chrom'", "'start'", "'end'")}
+                <-  {'fields': ('chrom', 'start', 'end')}
             <-  chrom: string
                 start: int64
                 end: int64
-        <-  oxbow._core.feature.BedFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_feature.TestBedFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBedFile.test_init_callstack.yaml
@@ -1,15 +1,15 @@
 BedFile("data/does-not-exist.bed"): |-
-    ->  oxbow._core.feature.BedFile.__init__("data/does-not-exist.bed")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bed", None, None)
+    ->  oxbow._core.feature.BedFile.__init__(data/does-not-exist.bed)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bed, None, None)
         <-  None
     <-  None
 BedFile("data/malformed.bed"): |-
-    ->  oxbow._core.feature.BedFile.__init__("data/malformed.bed")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.bed", None, None)
+    ->  oxbow._core.feature.BedFile.__init__(data/malformed.bed)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.bed, None, None)
         <-  None
     <-  None
 BedFile("data/sample.bed"): |-
-    ->  oxbow._core.feature.BedFile.__init__("data/sample.bed")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.bed", None, None)
+    ->  oxbow._core.feature.BedFile.__init__(data/sample.bed)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.bed, None, None)
         <-  None
     <-  None

--- a/py-oxbow/tests/manifests/test_feature.TestBedFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBedFile.test_select_callstack.yaml
@@ -3,11 +3,11 @@ BedFile("data/does-not-exist.bed").select(): |-
         ->  oxbow._core.feature.BedFile._scan_kwargs
         <-  {'fields': 'None'}
         ->  oxbow._core.feature.BedFile._scanner_kwargs
-        <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+        <-  {'bed_schema': 'bed3', 'compressed': 'False'}
         ->  oxbow._core.feature.BedFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BedFile.__init__("data/does-not-exist.bed", None, fields=None, bed_schema="bed3", compressed=False)
-            ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bed", None, None)
+        ->  oxbow._core.feature.BedFile.__init__(data/does-not-exist.bed, None, fields=None, bed_schema=bed3, compressed=False)
+            ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bed, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -16,9 +16,9 @@ BedFile("data/does-not-exist.bed").select(): |-
                 <-  BedFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/does-not-exist.bed'
+                    <-  data/does-not-exist.bed
                     ->  oxbow._core.feature.BedFile._scanner_kwargs
-                    <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+                    <-  {'bed_schema': 'bed3', 'compressed': 'False'}
                 !!  FileNotFoundError('No such file or directory (os error 2)')
             !!  UnboundLocalError('cannot access local variable "previous" where it is not associated with a value')
         !!  UnboundLocalError('cannot access local variable "previous" where it is not associated with a value')
@@ -28,11 +28,11 @@ BedFile("data/malformed.bed").select(): |-
         ->  oxbow._core.feature.BedFile._scan_kwargs
         <-  {'fields': 'None'}
         ->  oxbow._core.feature.BedFile._scanner_kwargs
-        <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+        <-  {'bed_schema': 'bed3', 'compressed': 'False'}
         ->  oxbow._core.feature.BedFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BedFile.__init__("data/malformed.bed", None, fields=None, bed_schema="bed3", compressed=False)
-            ->  oxbow._core.base.DataSource.__init__("data/malformed.bed", None, None)
+        ->  oxbow._core.feature.BedFile.__init__(data/malformed.bed, None, fields=None, bed_schema=bed3, compressed=False)
+            ->  oxbow._core.base.DataSource.__init__(data/malformed.bed, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -41,24 +41,26 @@ BedFile("data/malformed.bed").select(): |-
                 <-  BedFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/malformed.bed'
+                    <-  data/malformed.bed
                     ->  oxbow._core.feature.BedFile._scanner_kwargs
-                    <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+                    <-  {'bed_schema': 'bed3', 'compressed': 'False'}
                 <-  builtins.PyBedScanner.<object>
+                ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.feature.BedFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/malformed.bed'
+                            <-  data/malformed.bed
                             ->  oxbow._core.feature.BedFile._scanner_kwargs
-                            <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+                            <-  {'bed_schema': 'bed3', 'compressed': 'False'}
                         <-  builtins.PyBedScanner.<object>
                         ->  oxbow._core.feature.BedFile._schema_kwargs
                         <-  {'fields': 'None'}
                     <-  chrom: string
                         start: int64
                         end: int64
-                <-  oxbow._core.feature.BedFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>
@@ -67,11 +69,11 @@ BedFile("data/sample.bed").select(): |-
         ->  oxbow._core.feature.BedFile._scan_kwargs
         <-  {'fields': 'None'}
         ->  oxbow._core.feature.BedFile._scanner_kwargs
-        <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+        <-  {'bed_schema': 'bed3', 'compressed': 'False'}
         ->  oxbow._core.feature.BedFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BedFile.__init__("data/sample.bed", None, fields=None, bed_schema="bed3", compressed=False)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.bed", None, None)
+        ->  oxbow._core.feature.BedFile.__init__(data/sample.bed, None, fields=None, bed_schema=bed3, compressed=False)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.bed, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -80,24 +82,26 @@ BedFile("data/sample.bed").select(): |-
                 <-  BedFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bed'
+                    <-  data/sample.bed
                     ->  oxbow._core.feature.BedFile._scanner_kwargs
-                    <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+                    <-  {'bed_schema': 'bed3', 'compressed': 'False'}
                 <-  builtins.PyBedScanner.<object>
+                ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.feature.BedFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.bed'
+                            <-  data/sample.bed
                             ->  oxbow._core.feature.BedFile._scanner_kwargs
-                            <-  {'bed_schema': "'bed3'", 'compressed': 'False'}
+                            <-  {'bed_schema': 'bed3', 'compressed': 'False'}
                         <-  builtins.PyBedScanner.<object>
                         ->  oxbow._core.feature.BedFile._schema_kwargs
                         <-  {'fields': 'None'}
                     <-  chrom: string
                         start: int64
                         end: int64
-                <-  oxbow._core.feature.BedFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_feature.TestBigBedFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBigBedFile.test_batches_callstack.yaml
@@ -6,23 +6,25 @@ BigBedFile("data/sample.bb", fields=('chrom', 'start', 'end')).batches(batch_siz
     ->  oxbow._core.feature.BbiFile._scanner
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.bb'
+            <-  data/sample.bb
             ->  oxbow._core.feature.BbiFile._scanner_kwargs
             <-  {}
         <-  builtins.PyBigBedScanner.<object>
     <-  builtins.PyBigBedScanner.<object>
+    ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.feature.BbiFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.feature.BbiFile._scanner
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bb'
+                    <-  data/sample.bb
                     ->  oxbow._core.feature.BbiFile._scanner_kwargs
                     <-  {}
                 <-  builtins.PyBigBedScanner.<object>
             <-  builtins.PyBigBedScanner.<object>
             ->  oxbow._core.feature.BbiFile._schema_kwargs
-            <-  {'fields': ("'chrom'", "'start'", "'end'")}
+            <-  {'fields': ('chrom', 'start', 'end')}
         <-  chrom: string
             start: uint32
             end: uint32
@@ -206,4 +208,4 @@ BigBedFile("data/sample.bb", fields=('chrom', 'start', 'end')).batches(batch_siz
             chrom: ["chr21","chr21","chr21","chr21","chr21"]
             start: [46073935,46077849,46270819,46442909,46715593]
             end: [46074545,46078401,46271271,46443662,46715716]
-    <-  oxbow._core.feature.BbiFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_feature.TestBigBedFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBigBedFile.test_fragments_callstack.yaml
@@ -5,25 +5,27 @@ BigBedFile("data/sample.bb", fields=('chrom', 'start', 'end')).batches(batch_siz
         ->  oxbow._core.feature.BbiFile._scanner
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bb'
+                <-  data/sample.bb
                 ->  oxbow._core.feature.BbiFile._scanner_kwargs
                 <-  {}
             <-  builtins.PyBigBedScanner.<object>
         <-  builtins.PyBigBedScanner.<object>
+        ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.feature.BbiFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.feature.BbiFile._scanner
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/sample.bb'
+                        <-  data/sample.bb
                         ->  oxbow._core.feature.BbiFile._scanner_kwargs
                         <-  {}
                     <-  builtins.PyBigBedScanner.<object>
                 <-  builtins.PyBigBedScanner.<object>
                 ->  oxbow._core.feature.BbiFile._schema_kwargs
-                <-  {'fields': ("'chrom'", "'start'", "'end'")}
+                <-  {'fields': ('chrom', 'start', 'end')}
             <-  chrom: string
                 start: uint32
                 end: uint32
-        <-  oxbow._core.feature.BbiFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_feature.TestBigBedFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBigBedFile.test_init_callstack.yaml
@@ -1,21 +1,21 @@
 BigBedFile("data/does-not-exist.bb"): |-
-    ->  oxbow._core.feature.BigBedFile.__init__("data/does-not-exist.bb")
-        ->  oxbow._core.feature.BbiFile.__init__("data/does-not-exist.bb")
-            ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bb", None, None)
+    ->  oxbow._core.feature.BigBedFile.__init__(data/does-not-exist.bb)
+        ->  oxbow._core.feature.BbiFile.__init__(data/does-not-exist.bb)
+            ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bb, None, None)
             <-  None
         <-  None
     <-  None
 BigBedFile("data/malformed.bb"): |-
-    ->  oxbow._core.feature.BigBedFile.__init__("data/malformed.bb")
-        ->  oxbow._core.feature.BbiFile.__init__("data/malformed.bb")
-            ->  oxbow._core.base.DataSource.__init__("data/malformed.bb", None, None)
+    ->  oxbow._core.feature.BigBedFile.__init__(data/malformed.bb)
+        ->  oxbow._core.feature.BbiFile.__init__(data/malformed.bb)
+            ->  oxbow._core.base.DataSource.__init__(data/malformed.bb, None, None)
             <-  None
         <-  None
     <-  None
 BigBedFile("data/sample.bb"): |-
-    ->  oxbow._core.feature.BigBedFile.__init__("data/sample.bb")
-        ->  oxbow._core.feature.BbiFile.__init__("data/sample.bb")
-            ->  oxbow._core.base.DataSource.__init__("data/sample.bb", None, None)
+    ->  oxbow._core.feature.BigBedFile.__init__(data/sample.bb)
+        ->  oxbow._core.feature.BbiFile.__init__(data/sample.bb)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.bb, None, None)
             <-  None
         <-  None
     <-  None

--- a/py-oxbow/tests/manifests/test_feature.TestBigBedFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBigBedFile.test_select_callstack.yaml
@@ -6,9 +6,9 @@ BigBedFile("data/does-not-exist.bb").select(): |-
         <-  {}
         ->  oxbow._core.feature.BbiFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BigBedFile.__init__("data/does-not-exist.bb", None, fields=None)
-            ->  oxbow._core.feature.BbiFile.__init__("data/does-not-exist.bb", None, fields=None)
-                ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bb", None, None)
+        ->  oxbow._core.feature.BigBedFile.__init__(data/does-not-exist.bb, None, fields=None)
+            ->  oxbow._core.feature.BbiFile.__init__(data/does-not-exist.bb, None, fields=None)
+                ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bb, None, None)
                 <-  None
             <-  None
         <-  None
@@ -19,7 +19,7 @@ BigBedFile("data/does-not-exist.bb").select(): |-
                 ->  oxbow._core.feature.BbiFile._scanner
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/does-not-exist.bb'
+                        <-  data/does-not-exist.bb
                         ->  oxbow._core.feature.BbiFile._scanner_kwargs
                         <-  {}
                     !!  FileNotFoundError('No such file or directory (os error 2)')
@@ -35,9 +35,9 @@ BigBedFile("data/malformed.bb").select(): |-
         <-  {}
         ->  oxbow._core.feature.BbiFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BigBedFile.__init__("data/malformed.bb", None, fields=None)
-            ->  oxbow._core.feature.BbiFile.__init__("data/malformed.bb", None, fields=None)
-                ->  oxbow._core.base.DataSource.__init__("data/malformed.bb", None, None)
+        ->  oxbow._core.feature.BigBedFile.__init__(data/malformed.bb, None, fields=None)
+            ->  oxbow._core.feature.BbiFile.__init__(data/malformed.bb, None, fields=None)
+                ->  oxbow._core.base.DataSource.__init__(data/malformed.bb, None, None)
                 <-  None
             <-  None
         <-  None
@@ -48,7 +48,7 @@ BigBedFile("data/malformed.bb").select(): |-
                 ->  oxbow._core.feature.BbiFile._scanner
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/malformed.bb'
+                        <-  data/malformed.bb
                         ->  oxbow._core.feature.BbiFile._scanner_kwargs
                         <-  {}
                     !!  PanicException('called `Result::unwrap()` on an `Err` value: NotABigBed')
@@ -64,9 +64,9 @@ BigBedFile("data/sample.bb").select(): |-
         <-  {}
         ->  oxbow._core.feature.BbiFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BigBedFile.__init__("data/sample.bb", None, fields=None)
-            ->  oxbow._core.feature.BbiFile.__init__("data/sample.bb", None, fields=None)
-                ->  oxbow._core.base.DataSource.__init__("data/sample.bb", None, None)
+        ->  oxbow._core.feature.BigBedFile.__init__(data/sample.bb, None, fields=None)
+            ->  oxbow._core.feature.BbiFile.__init__(data/sample.bb, None, fields=None)
+                ->  oxbow._core.base.DataSource.__init__(data/sample.bb, None, None)
                 <-  None
             <-  None
         <-  None
@@ -77,17 +77,19 @@ BigBedFile("data/sample.bb").select(): |-
                 ->  oxbow._core.feature.BbiFile._scanner
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/sample.bb'
+                        <-  data/sample.bb
                         ->  oxbow._core.feature.BbiFile._scanner_kwargs
                         <-  {}
                     <-  builtins.PyBigBedScanner.<object>
                 <-  builtins.PyBigBedScanner.<object>
+                ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.feature.BbiFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.feature.BbiFile._scanner
                             ->  oxbow._core.base.DataSource._scanner
                                 ->  oxbow._core.base.DataSource._source
-                                <-  'data/sample.bb'
+                                <-  data/sample.bb
                                 ->  oxbow._core.feature.BbiFile._scanner_kwargs
                                 <-  {}
                             <-  builtins.PyBigBedScanner.<object>
@@ -98,7 +100,7 @@ BigBedFile("data/sample.bb").select(): |-
                         start: uint32
                         end: uint32
                         rest: string
-                <-  oxbow._core.feature.BbiFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_feature.TestBigWigFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBigWigFile.test_batches_callstack.yaml
@@ -6,23 +6,25 @@ BigWigFile("data/sample.bw", fields=('chrom', 'start', 'end')).batches(batch_siz
     ->  oxbow._core.feature.BbiFile._scanner
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.bw'
+            <-  data/sample.bw
             ->  oxbow._core.feature.BbiFile._scanner_kwargs
             <-  {}
         <-  builtins.PyBigWigScanner.<object>
     <-  builtins.PyBigWigScanner.<object>
+    ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.feature.BbiFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.feature.BbiFile._scanner
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bw'
+                    <-  data/sample.bw
                     ->  oxbow._core.feature.BbiFile._scanner_kwargs
                     <-  {}
                 <-  builtins.PyBigWigScanner.<object>
             <-  builtins.PyBigWigScanner.<object>
             ->  oxbow._core.feature.BbiFile._schema_kwargs
-            <-  {'fields': ("'chrom'", "'start'", "'end'")}
+            <-  {'fields': ('chrom', 'start', 'end')}
         <-  chrom: string
             start: uint32
             end: uint32
@@ -206,4 +208,4 @@ BigWigFile("data/sample.bw", fields=('chrom', 'start', 'end')).batches(batch_siz
             chrom: ["chr21","chr21","chr21","chr21","chr21"]
             start: [46804590,47098130,47167470,47424830,47650460]
             end: [46804595,47098140,47167475,47424835,47650465]
-    <-  oxbow._core.feature.BbiFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_feature.TestBigWigFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBigWigFile.test_fragments_callstack.yaml
@@ -5,25 +5,27 @@ BigWigFile("data/sample.bw", fields=('chrom', 'start', 'end')).batches(batch_siz
         ->  oxbow._core.feature.BbiFile._scanner
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bw'
+                <-  data/sample.bw
                 ->  oxbow._core.feature.BbiFile._scanner_kwargs
                 <-  {}
             <-  builtins.PyBigWigScanner.<object>
         <-  builtins.PyBigWigScanner.<object>
+        ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.feature.BbiFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.feature.BbiFile._scanner
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/sample.bw'
+                        <-  data/sample.bw
                         ->  oxbow._core.feature.BbiFile._scanner_kwargs
                         <-  {}
                     <-  builtins.PyBigWigScanner.<object>
                 <-  builtins.PyBigWigScanner.<object>
                 ->  oxbow._core.feature.BbiFile._schema_kwargs
-                <-  {'fields': ("'chrom'", "'start'", "'end'")}
+                <-  {'fields': ('chrom', 'start', 'end')}
             <-  chrom: string
                 start: uint32
                 end: uint32
-        <-  oxbow._core.feature.BbiFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_feature.TestBigWigFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBigWigFile.test_init_callstack.yaml
@@ -1,15 +1,15 @@
 BigWigFile("data/does-not-exist.bw"): |-
-    ->  oxbow._core.feature.BbiFile.__init__("data/does-not-exist.bw")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bw", None, None)
+    ->  oxbow._core.feature.BbiFile.__init__(data/does-not-exist.bw)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bw, None, None)
         <-  None
     <-  None
 BigWigFile("data/malformed.bw"): |-
-    ->  oxbow._core.feature.BbiFile.__init__("data/malformed.bw")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.bw", None, None)
+    ->  oxbow._core.feature.BbiFile.__init__(data/malformed.bw)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.bw, None, None)
         <-  None
     <-  None
 BigWigFile("data/sample.bw"): |-
-    ->  oxbow._core.feature.BbiFile.__init__("data/sample.bw")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.bw", None, None)
+    ->  oxbow._core.feature.BbiFile.__init__(data/sample.bw)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.bw, None, None)
         <-  None
     <-  None

--- a/py-oxbow/tests/manifests/test_feature.TestBigWigFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestBigWigFile.test_select_callstack.yaml
@@ -6,8 +6,8 @@ BigWigFile("data/does-not-exist.bw").select(): |-
         <-  {}
         ->  oxbow._core.feature.BbiFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BbiFile.__init__("data/does-not-exist.bw", None, fields=None)
-            ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bw", None, None)
+        ->  oxbow._core.feature.BbiFile.__init__(data/does-not-exist.bw, None, fields=None)
+            ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bw, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -17,7 +17,7 @@ BigWigFile("data/does-not-exist.bw").select(): |-
                 ->  oxbow._core.feature.BbiFile._scanner
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/does-not-exist.bw'
+                        <-  data/does-not-exist.bw
                         ->  oxbow._core.feature.BbiFile._scanner_kwargs
                         <-  {}
                     !!  FileNotFoundError('No such file or directory (os error 2)')
@@ -33,8 +33,8 @@ BigWigFile("data/malformed.bw").select(): |-
         <-  {}
         ->  oxbow._core.feature.BbiFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BbiFile.__init__("data/malformed.bw", None, fields=None)
-            ->  oxbow._core.base.DataSource.__init__("data/malformed.bw", None, None)
+        ->  oxbow._core.feature.BbiFile.__init__(data/malformed.bw, None, fields=None)
+            ->  oxbow._core.base.DataSource.__init__(data/malformed.bw, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -44,7 +44,7 @@ BigWigFile("data/malformed.bw").select(): |-
                 ->  oxbow._core.feature.BbiFile._scanner
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/malformed.bw'
+                        <-  data/malformed.bw
                         ->  oxbow._core.feature.BbiFile._scanner_kwargs
                         <-  {}
                     !!  PanicException('called `Result::unwrap()` on an `Err` value: NotABigWig')
@@ -60,8 +60,8 @@ BigWigFile("data/sample.bw").select(): |-
         <-  {}
         ->  oxbow._core.feature.BbiFile._schema_kwargs
         <-  {'fields': 'None'}
-        ->  oxbow._core.feature.BbiFile.__init__("data/sample.bw", None, fields=None)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.bw", None, None)
+        ->  oxbow._core.feature.BbiFile.__init__(data/sample.bw, None, fields=None)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.bw, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -71,17 +71,19 @@ BigWigFile("data/sample.bw").select(): |-
                 ->  oxbow._core.feature.BbiFile._scanner
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/sample.bw'
+                        <-  data/sample.bw
                         ->  oxbow._core.feature.BbiFile._scanner_kwargs
                         <-  {}
                     <-  builtins.PyBigWigScanner.<object>
                 <-  builtins.PyBigWigScanner.<object>
+                ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.feature.BbiFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.feature.BbiFile._scanner
                             ->  oxbow._core.base.DataSource._scanner
                                 ->  oxbow._core.base.DataSource._source
-                                <-  'data/sample.bw'
+                                <-  data/sample.bw
                                 ->  oxbow._core.feature.BbiFile._scanner_kwargs
                                 <-  {}
                             <-  builtins.PyBigWigScanner.<object>
@@ -92,7 +94,7 @@ BigWigFile("data/sample.bw").select(): |-
                         start: uint32
                         end: uint32
                         value: float
-                <-  oxbow._core.feature.BbiFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_feature.TestGffFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestGffFile.test_batches_callstack.yaml
@@ -5,22 +5,24 @@ GffFile("data/sample.gff", fields=('seqid', 'start', 'end')).batches(batch_size=
     <-  GxfFile._batch_readers.<generator>
     ->  oxbow._core.base.DataSource._scanner
         ->  oxbow._core.base.DataSource._source
-        <-  'data/sample.gff'
+        <-  data/sample.gff
         ->  oxbow._core.feature.GxfFile._scanner_kwargs
         <-  {'compressed': 'False'}
     <-  builtins.PyGffScanner.<object>
     ->  oxbow._core.feature.GxfFile._scan_kwargs
-    <-  {'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': ("'seqid'", "'start'", "'end'")}
+    <-  {'attribute_defs': [('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': ('seqid', 'start', 'end')}
+    ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyGffScanner.scan, attribute_defs=[("ID", "String"), ("Parent", "String"), ("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), "<", "8", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], fields=("seqid", "start", "end"))>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.feature.GxfFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.gff'
+                <-  data/sample.gff
                 ->  oxbow._core.feature.GxfFile._scanner_kwargs
                 <-  {'compressed': 'False'}
             <-  builtins.PyGffScanner.<object>
             ->  oxbow._core.feature.GxfFile._schema_kwargs
-            <-  {'fields': ("'seqid'", "'start'", "'end'"), 'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+            <-  {'fields': ('seqid', 'start', 'end'), 'attribute_defs': [('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
         <-  seqid: string
             start: int32
             end: int32
@@ -308,4 +310,4 @@ GffFile("data/sample.gff", fields=('seqid', 'start', 'end')).batches(batch_size=
             ["2","5","5","5","5"]
             -- child 17 type: string
             ["nonsense_mediated_decay","protein_coding","lncRNA","protein_coding","protein_coding"]
-    <-  oxbow._core.feature.GxfFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_feature.TestGffFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestGffFile.test_fragments_callstack.yaml
@@ -4,22 +4,24 @@ GffFile("data/sample.gff", fields=('seqid', 'start', 'end')).batches(batch_size=
         <-  GxfFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.gff'
+            <-  data/sample.gff
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGffScanner.<object>
         ->  oxbow._core.feature.GxfFile._scan_kwargs
-        <-  {'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': ("'seqid'", "'start'", "'end'")}
+        <-  {'attribute_defs': [('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': ('seqid', 'start', 'end')}
+        ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyGffScanner.scan, attribute_defs=[("ID", "String"), ("Parent", "String"), ("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), "<", "8", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], fields=("seqid", "start", "end"))>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.feature.GxfFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.gff'
+                    <-  data/sample.gff
                     ->  oxbow._core.feature.GxfFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  builtins.PyGffScanner.<object>
                 ->  oxbow._core.feature.GxfFile._schema_kwargs
-                <-  {'fields': ("'seqid'", "'start'", "'end'"), 'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+                <-  {'fields': ('seqid', 'start', 'end'), 'attribute_defs': [('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
             <-  seqid: string
                 start: int32
                 end: int32
@@ -43,5 +45,5 @@ GffFile("data/sample.gff", fields=('seqid', 'start', 'end')).batches(batch_size=
                   child 15, transcript_name: string
                   child 16, transcript_support_level: string
                   child 17, transcript_type: string
-        <-  oxbow._core.feature.GxfFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_feature.TestGffFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestGffFile.test_init_callstack.yaml
@@ -1,32 +1,32 @@
 GffFile("data/does-not-exist.gff"): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/does-not-exist.gff")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.gff", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/does-not-exist.gff)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.gff, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/does-not-exist.gff'
+            <-  data/does-not-exist.gff
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  PanicException('called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }')
     !!  PanicException("called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: 'No such file or directory' }")
 GffFile("data/malformed.gff"): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/malformed.gff")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.gff", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/malformed.gff)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.gff, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/malformed.gff'
+            <-  data/malformed.gff
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGffScanner.<object>
     !!  OSError("unexpected end of file")
 GffFile("data/sample.gff"): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/sample.gff")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.gff", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/sample.gff)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.gff, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.gff'
+            <-  data/sample.gff
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGffScanner.<object>

--- a/py-oxbow/tests/manifests/test_feature.TestGffFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestGffFile.test_select_callstack.yaml
@@ -1,45 +1,45 @@
 GffFile("data/does-not-exist.gff").select(): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/does-not-exist.gff")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.gff", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/does-not-exist.gff)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.gff, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/does-not-exist.gff'
+            <-  data/does-not-exist.gff
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  PanicException('called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }')
     !!  PanicException("called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: 'No such file or directory' }")
 GffFile("data/malformed.gff").select(): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/malformed.gff")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.gff", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/malformed.gff)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.gff, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/malformed.gff'
+            <-  data/malformed.gff
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGffScanner.<object>
     !!  OSError("unexpected end of file")
 GffFile("data/sample.gff").select(): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/sample.gff")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.gff", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/sample.gff)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.gff, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.gff'
+            <-  data/sample.gff
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGffScanner.<object>
     <-  None
     ->  oxbow._core.base.DataSource.select()
         ->  oxbow._core.feature.GxfFile._scan_kwargs
-        <-  {'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+        <-  {'attribute_defs': [('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
         ->  oxbow._core.feature.GxfFile._scanner_kwargs
         <-  {'compressed': 'False'}
         ->  oxbow._core.feature.GxfFile._schema_kwargs
-        <-  {'fields': 'None', 'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
-        ->  oxbow._core.feature.GxfFile.__init__("data/sample.gff", None, attribute_defs=[("ID", "String"), ("Parent", "String"), ("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), ("protein_id", "String"), ("tag", "Array"), ("transcript_id", "String"), ("transcript_name", "String"), ("transcript_support_level", "String"), ("transcript_type", "String")], fields=None, compressed=False)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.gff", None, None)
+        <-  {'fields': 'None', 'attribute_defs': [('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+        ->  oxbow._core.feature.GxfFile.__init__(data/sample.gff, None, attribute_defs=[('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], fields=None, compressed=False)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.gff, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -48,22 +48,24 @@ GffFile("data/sample.gff").select(): |-
                 <-  GxfFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.gff'
+                    <-  data/sample.gff
                     ->  oxbow._core.feature.GxfFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  builtins.PyGffScanner.<object>
                 ->  oxbow._core.feature.GxfFile._scan_kwargs
-                <-  {'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+                <-  {'attribute_defs': [('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+                ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyGffScanner.scan, attribute_defs=[("ID", "String"), ("Parent", "String"), ("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), "<", "8", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], fields=None)>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.feature.GxfFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.gff'
+                            <-  data/sample.gff
                             ->  oxbow._core.feature.GxfFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         <-  builtins.PyGffScanner.<object>
                         ->  oxbow._core.feature.GxfFile._schema_kwargs
-                        <-  {'fields': 'None', 'attribute_defs': [("'ID'", "'String'"), ("'Parent'", "'String'"), ("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+                        <-  {'fields': 'None', 'attribute_defs': [('ID', 'String'), ('Parent', 'String'), ('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), '<', '8', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
                     <-  seqid: string
                         source: string
                         type: string
@@ -92,7 +94,7 @@ GffFile("data/sample.gff").select(): |-
                           child 15, transcript_name: string
                           child 16, transcript_support_level: string
                           child 17, transcript_type: string
-                <-  oxbow._core.feature.GxfFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_feature.TestGtfFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestGtfFile.test_batches_callstack.yaml
@@ -5,22 +5,24 @@ GtfFile("data/sample.gtf", fields=('seqid', 'start', 'end')).batches(batch_size=
     <-  GxfFile._batch_readers.<generator>
     ->  oxbow._core.base.DataSource._scanner
         ->  oxbow._core.base.DataSource._source
-        <-  'data/sample.gtf'
+        <-  data/sample.gtf
         ->  oxbow._core.feature.GxfFile._scanner_kwargs
         <-  {'compressed': 'False'}
     <-  builtins.PyGtfScanner.<object>
     ->  oxbow._core.feature.GxfFile._scan_kwargs
-    <-  {'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': ("'seqid'", "'start'", "'end'")}
+    <-  {'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': ('seqid', 'start', 'end')}
+    ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyGtfScanner.scan, attribute_defs=[("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), "<", "6", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], fields=("seqid", "start", "end"))>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.feature.GxfFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.gtf'
+                <-  data/sample.gtf
                 ->  oxbow._core.feature.GxfFile._scanner_kwargs
                 <-  {'compressed': 'False'}
             <-  builtins.PyGtfScanner.<object>
             ->  oxbow._core.feature.GxfFile._schema_kwargs
-            <-  {'fields': ("'seqid'", "'start'", "'end'"), 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+            <-  {'fields': ('seqid', 'start', 'end'), 'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
         <-  seqid: string
             start: int32
             end: int32
@@ -277,4 +279,4 @@ GtfFile("data/sample.gtf", fields=('seqid', 'start', 'end')).batches(batch_size=
             [null,null,"5","5","5"]
             -- child 15 type: string
             ["retained_intron","lncRNA","protein_coding","protein_coding","protein_coding"]
-    <-  oxbow._core.feature.GxfFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_feature.TestGtfFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestGtfFile.test_fragments_callstack.yaml
@@ -4,22 +4,24 @@ GtfFile("data/sample.gtf", fields=('seqid', 'start', 'end')).batches(batch_size=
         <-  GxfFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.gtf'
+            <-  data/sample.gtf
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGtfScanner.<object>
         ->  oxbow._core.feature.GxfFile._scan_kwargs
-        <-  {'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': ("'seqid'", "'start'", "'end'")}
+        <-  {'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': ('seqid', 'start', 'end')}
+        ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyGtfScanner.scan, attribute_defs=[("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), "<", "6", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], fields=("seqid", "start", "end"))>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.feature.GxfFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.gtf'
+                    <-  data/sample.gtf
                     ->  oxbow._core.feature.GxfFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  builtins.PyGtfScanner.<object>
                 ->  oxbow._core.feature.GxfFile._schema_kwargs
-                <-  {'fields': ("'seqid'", "'start'", "'end'"), 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+                <-  {'fields': ('seqid', 'start', 'end'), 'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
             <-  seqid: string
                 start: int32
                 end: int32
@@ -40,5 +42,5 @@ GtfFile("data/sample.gtf", fields=('seqid', 'start', 'end')).batches(batch_size=
                   child 13, transcript_name: string
                   child 14, transcript_support_level: string
                   child 15, transcript_type: string
-        <-  oxbow._core.feature.GxfFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_feature.TestGtfFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestGtfFile.test_init_callstack.yaml
@@ -1,32 +1,32 @@
 GtfFile("data/does-not-exist.gtf"): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/does-not-exist.gtf")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.gtf", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/does-not-exist.gtf)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.gtf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/does-not-exist.gtf'
+            <-  data/does-not-exist.gtf
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  FileNotFoundError('No such file or directory (os error 2)')
     !!  FileNotFoundError("No such file or directory (os error 2)")
 GtfFile("data/malformed.gtf"): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/malformed.gtf")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.gtf", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/malformed.gtf)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.gtf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/malformed.gtf'
+            <-  data/malformed.gtf
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGtfScanner.<object>
     <-  None
 GtfFile("data/sample.gtf"): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/sample.gtf")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.gtf", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/sample.gtf)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.gtf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.gtf'
+            <-  data/sample.gtf
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGtfScanner.<object>

--- a/py-oxbow/tests/manifests/test_feature.TestGtfFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_feature.TestGtfFile.test_select_callstack.yaml
@@ -1,34 +1,34 @@
 GtfFile("data/does-not-exist.gtf").select(): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/does-not-exist.gtf")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.gtf", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/does-not-exist.gtf)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.gtf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/does-not-exist.gtf'
+            <-  data/does-not-exist.gtf
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  FileNotFoundError('No such file or directory (os error 2)')
     !!  FileNotFoundError("No such file or directory (os error 2)")
 GtfFile("data/malformed.gtf").select(): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/malformed.gtf")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.gtf", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/malformed.gtf)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.gtf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/malformed.gtf'
+            <-  data/malformed.gtf
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGtfScanner.<object>
     <-  None
     ->  oxbow._core.base.DataSource.select()
         ->  oxbow._core.feature.GxfFile._scan_kwargs
-        <-  {'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+        <-  {'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
         ->  oxbow._core.feature.GxfFile._scanner_kwargs
         <-  {'compressed': 'False'}
         ->  oxbow._core.feature.GxfFile._schema_kwargs
-        <-  {'fields': 'None', 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
-        ->  oxbow._core.feature.GxfFile.__init__("data/malformed.gtf", None, attribute_defs=[("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), ("protein_id", "String"), ("tag", "String"), ("transcript_id", "String"), ("transcript_name", "String"), ("transcript_support_level", "String"), ("transcript_type", "String")], fields=None, compressed=False)
-            ->  oxbow._core.base.DataSource.__init__("data/malformed.gtf", None, None)
+        <-  {'fields': 'None', 'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+        ->  oxbow._core.feature.GxfFile.__init__(data/malformed.gtf, None, attribute_defs=[('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], fields=None, compressed=False)
+            ->  oxbow._core.base.DataSource.__init__(data/malformed.gtf, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -37,22 +37,24 @@ GtfFile("data/malformed.gtf").select(): |-
                 <-  GxfFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/malformed.gtf'
+                    <-  data/malformed.gtf
                     ->  oxbow._core.feature.GxfFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  builtins.PyGtfScanner.<object>
                 ->  oxbow._core.feature.GxfFile._scan_kwargs
-                <-  {'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+                <-  {'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+                ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyGtfScanner.scan, attribute_defs=[("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), "<", "6", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], fields=None)>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.feature.GxfFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/malformed.gtf'
+                            <-  data/malformed.gtf
                             ->  oxbow._core.feature.GxfFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         <-  builtins.PyGtfScanner.<object>
                         ->  oxbow._core.feature.GxfFile._schema_kwargs
-                        <-  {'fields': 'None', 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+                        <-  {'fields': 'None', 'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
                     <-  seqid: string
                         source: string
                         type: string
@@ -78,30 +80,30 @@ GtfFile("data/malformed.gtf").select(): |-
                           child 13, transcript_name: string
                           child 14, transcript_support_level: string
                           child 15, transcript_type: string
-                <-  oxbow._core.feature.GxfFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>
 GtfFile("data/sample.gtf").select(): |-
-    ->  oxbow._core.feature.GxfFile.__init__("data/sample.gtf")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.gtf", None, None)
+    ->  oxbow._core.feature.GxfFile.__init__(data/sample.gtf)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.gtf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.gtf'
+            <-  data/sample.gtf
             ->  oxbow._core.feature.GxfFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  builtins.PyGtfScanner.<object>
     <-  None
     ->  oxbow._core.base.DataSource.select()
         ->  oxbow._core.feature.GxfFile._scan_kwargs
-        <-  {'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+        <-  {'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
         ->  oxbow._core.feature.GxfFile._scanner_kwargs
         <-  {'compressed': 'False'}
         ->  oxbow._core.feature.GxfFile._schema_kwargs
-        <-  {'fields': 'None', 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
-        ->  oxbow._core.feature.GxfFile.__init__("data/sample.gtf", None, attribute_defs=[("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), ("protein_id", "String"), ("tag", "String"), ("transcript_id", "String"), ("transcript_name", "String"), ("transcript_support_level", "String"), ("transcript_type", "String")], fields=None, compressed=False)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.gtf", None, None)
+        <-  {'fields': 'None', 'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+        ->  oxbow._core.feature.GxfFile.__init__(data/sample.gtf, None, attribute_defs=[('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], fields=None, compressed=False)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.gtf, None, None)
             <-  None
         <-  None
         ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -110,22 +112,24 @@ GtfFile("data/sample.gtf").select(): |-
                 <-  GxfFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.gtf'
+                    <-  data/sample.gtf
                     ->  oxbow._core.feature.GxfFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  builtins.PyGtfScanner.<object>
                 ->  oxbow._core.feature.GxfFile._scan_kwargs
-                <-  {'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+                <-  {'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'fields': 'None'}
+                ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyGtfScanner.scan, attribute_defs=[("ccdsid", "String"), ("exon_id", "String"), ("exon_number", "String"), ("gene_id", "String"), ("gene_name", "String"), ("gene_type", "String"), ("havana_gene", "String"), ("havana_transcript", "String"), ("hgnc_id", "String"), ("level", "String"), "<", "6", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], fields=None)>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.feature.GxfFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.gtf'
+                            <-  data/sample.gtf
                             ->  oxbow._core.feature.GxfFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         <-  builtins.PyGtfScanner.<object>
                         ->  oxbow._core.feature.GxfFile._schema_kwargs
-                        <-  {'fields': 'None', 'attribute_defs': [("'ccdsid'", "'String'"), ("'exon_id'", "'String'"), ("'exon_number'", "'String'"), ("'gene_id'", "'String'"), ("'gene_name'", "'String'"), ("'gene_type'", "'String'"), ("'havana_gene'", "'String'"), ("'havana_transcript'", "'String'"), ("'hgnc_id'", "'String'"), ("'level'", "'String'"), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
+                        <-  {'fields': 'None', 'attribute_defs': [('ccdsid', 'String'), ('exon_id', 'String'), ('exon_number', 'String'), ('gene_id', 'String'), ('gene_name', 'String'), ('gene_type', 'String'), ('havana_gene', 'String'), ('havana_transcript', 'String'), ('hgnc_id', 'String'), ('level', 'String'), '<', '6', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>']}
                     <-  seqid: string
                         source: string
                         type: string
@@ -151,7 +155,7 @@ GtfFile("data/sample.gtf").select(): |-
                           child 13, transcript_name: string
                           child 14, transcript_support_level: string
                           child 15, transcript_type: string
-                <-  oxbow._core.feature.GxfFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_batches_callstack.yaml
@@ -5,20 +5,22 @@ FastaFile("data/sample.fasta", fields=('name', 'sequence')).fragments(batch_size
     <-  FastaFile._batch_readers.<generator>
     ->  oxbow._core.base.DataSource._scanner
         ->  oxbow._core.base.DataSource._source
-        <-  'data/sample.fasta'
+        <-  data/sample.fasta
         ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
         <-  {'compressed': 'False'}
     <-  oxbow.core.PyFastaScanner.<object>
+    ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.sequence.FastaFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.fasta'
+                <-  data/sample.fasta
                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                 <-  {'compressed': 'False'}
             <-  oxbow.core.PyFastaScanner.<object>
             ->  oxbow._core.sequence.SequenceFile._schema_kwargs
-            <-  {'fields': ("'name'", "'sequence'")}
+            <-  {'fields': ('name', 'sequence')}
         <-  name: string
             sequence: string
         ->  oxbow._core.base.DataSource.batches.<generator>
@@ -49,4 +51,4 @@ FastaFile("data/sample.fasta", fields=('name', 'sequence')).fragments(batch_size
             ----
             name: ["seq16","seq17","seq18","seq19","seq20"]
             sequence: ["GCATGCATGCATGCATGCATGCATGCATGCATGCATGC","ATCGATCGATCGATCGATCGATCGATCGATCGATCGAT","CTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTA","GATCGATCGATCGATCGATCGATCGATCGATCGATCGAT","TACGTACGTACGTACGTACGTACGTACGTACGTACGTAC"]
-    <-  oxbow._core.sequence.FastaFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_fragments_callstack.yaml
@@ -4,21 +4,23 @@ FastaFile("data/sample.fasta", fields=('name', 'sequence')).fragments(batch_size
         <-  FastaFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.fasta'
+            <-  data/sample.fasta
             ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyFastaScanner.<object>
+        ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.sequence.FastaFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.fasta'
+                    <-  data/sample.fasta
                     ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  oxbow.core.PyFastaScanner.<object>
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
-                <-  {'fields': ("'name'", "'sequence'")}
+                <-  {'fields': ('name', 'sequence')}
             <-  name: string
                 sequence: string
-        <-  oxbow._core.sequence.FastaFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_init_callstack.yaml
@@ -1,21 +1,21 @@
 FastaFile("data/does-not-exist.fasta"): |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/does-not-exist.fasta")
-        ->  oxbow._core.sequence.SequenceFile.__init__("data/does-not-exist.fasta", None, None, None, None, False)
-            ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.fasta", None, None)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/does-not-exist.fasta)
+        ->  oxbow._core.sequence.SequenceFile.__init__(data/does-not-exist.fasta, None, None, None, None, False)
+            ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.fasta, None, None)
             <-  None
         <-  None
     <-  None
 FastaFile("data/malformed.fasta"): |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/malformed.fasta")
-        ->  oxbow._core.sequence.SequenceFile.__init__("data/malformed.fasta", None, None, None, None, False)
-            ->  oxbow._core.base.DataSource.__init__("data/malformed.fasta", None, None)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/malformed.fasta)
+        ->  oxbow._core.sequence.SequenceFile.__init__(data/malformed.fasta, None, None, None, None, False)
+            ->  oxbow._core.base.DataSource.__init__(data/malformed.fasta, None, None)
             <-  None
         <-  None
     <-  None
 FastaFile("data/sample.fasta"): |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta")
-        ->  oxbow._core.sequence.SequenceFile.__init__("data/sample.fasta", None, None, None, None, False)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.fasta", None, None)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta)
+        ->  oxbow._core.sequence.SequenceFile.__init__(data/sample.fasta, None, None, None, None, False)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.fasta, None, None)
             <-  None
         <-  None
     <-  None

--- a/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_init_regions_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_init_regions_callstack.yaml
@@ -1,34 +1,34 @@
 ? FastaFile("data/sample.fasta", index="data/sample.fai", gzi=None, regions=["seq1:10-20",
     "seq10", "seq2:1-30"], compressed=False)
 : |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta", index="data/sample.fai", gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=False)
-        ->  oxbow._core.sequence.SequenceFile.__init__("data/sample.fasta", None, None, "data/sample.fai", None, False)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.fasta", None, None)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta, index=data/sample.fai, gzi=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'], compressed=False)
+        ->  oxbow._core.sequence.SequenceFile.__init__(data/sample.fasta, None, None, data/sample.fai, None, False)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.fasta, None, None)
             <-  None
         <-  None
     <-  None
 FastaFile("data/sample.fasta", index=None, gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=False): |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta", index=None, gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=False)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta, index=None, gzi=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'], compressed=False)
     !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
 ? FastaFile("data/sample.fasta.gz", index="data/sample.fai", gzi="data/sample.fasta.gzi",
     regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=True)
 : |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta.gz", index="data/sample.fai", gzi="data/sample.fasta.gzi", regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=True)
-        ->  oxbow._core.sequence.SequenceFile.__init__("data/sample.fasta.gz", None, None, "data/sample.fai", "data/sample.fasta.gzi", True)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.fasta.gz", None, None)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta.gz, index=data/sample.fai, gzi=data/sample.fasta.gzi, regions=['seq1:10-20', 'seq10', 'seq2:1-30'], compressed=True)
+        ->  oxbow._core.sequence.SequenceFile.__init__(data/sample.fasta.gz, None, None, data/sample.fai, data/sample.fasta.gzi, True)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.fasta.gz, None, None)
             <-  None
         <-  None
     <-  None
 ? FastaFile("data/sample.fasta.gz", index="data/sample.fai", gzi=None, regions=["seq1:10-20",
     "seq10", "seq2:1-30"], compressed=True)
 : |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta.gz", index="data/sample.fai", gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=True)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta.gz, index=data/sample.fai, gzi=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'], compressed=True)
     !!  ValueError("A GZI index file is required for BGZF-compressed FASTA when regions are specified.")
 ? FastaFile("data/sample.fasta.gz", index=None, gzi="data/sample.fasta.gzi", regions=["seq1:10-20",
     "seq10", "seq2:1-30"], compressed=True)
 : |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta.gz", index=None, gzi="data/sample.fasta.gzi", regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=True)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta.gz, index=None, gzi=data/sample.fasta.gzi, regions=['seq1:10-20', 'seq10', 'seq2:1-30'], compressed=True)
     !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
 FastaFile("data/sample.fasta.gz", index=None, gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=True): |-
-    ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta.gz", index=None, gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"], compressed=True)
+    ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta.gz, index=None, gzi=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'], compressed=True)
     !!  ValueError("A FAI index file is required for FASTA when regions are specified.")

--- a/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_select_callstack.yaml
@@ -8,9 +8,9 @@ FastaFile("data/does-not-exist.fasta").select(): |-
                 <-  {'compressed': 'False'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/does-not-exist.fasta", None, fields=None, compressed=False, gzi=None, index=None, regions=None)
-                    ->  oxbow._core.sequence.SequenceFile.__init__("data/does-not-exist.fasta", None, None, None, None, False)
-                        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.fasta", None, None)
+                ->  oxbow._core.sequence.FastaFile.__init__(data/does-not-exist.fasta, None, fields=None, compressed=False, gzi=None, index=None, regions=None)
+                    ->  oxbow._core.sequence.SequenceFile.__init__(data/does-not-exist.fasta, None, None, None, None, False)
+                        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.fasta, None, None)
                         <-  None
                     <-  None
                 <-  None
@@ -20,7 +20,7 @@ FastaFile("data/does-not-exist.fasta").select(): |-
                         <-  FastaFile._batch_readers.<generator>
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/does-not-exist.fasta'
+                            <-  data/does-not-exist.fasta
                             ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         !!  FileNotFoundError('No such file or directory (os error 2)')
@@ -39,9 +39,9 @@ FastaFile("data/malformed.fasta").select(): |-
                 <-  {'compressed': 'False'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/malformed.fasta", None, fields=None, compressed=False, gzi=None, index=None, regions=None)
-                    ->  oxbow._core.sequence.SequenceFile.__init__("data/malformed.fasta", None, None, None, None, False)
-                        ->  oxbow._core.base.DataSource.__init__("data/malformed.fasta", None, None)
+                ->  oxbow._core.sequence.FastaFile.__init__(data/malformed.fasta, None, fields=None, compressed=False, gzi=None, index=None, regions=None)
+                    ->  oxbow._core.sequence.SequenceFile.__init__(data/malformed.fasta, None, None, None, None, False)
+                        ->  oxbow._core.base.DataSource.__init__(data/malformed.fasta, None, None)
                         <-  None
                     <-  None
                 <-  None
@@ -51,15 +51,17 @@ FastaFile("data/malformed.fasta").select(): |-
                         <-  FastaFile._batch_readers.<generator>
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/malformed.fasta'
+                            <-  data/malformed.fasta
                             ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         <-  oxbow.core.PyFastaScanner.<object>
+                        ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+                        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                         ->  oxbow._core.sequence.FastaFile._batch_readers.<generator>
                             ->  oxbow._core.base.DataSource.schema
                                 ->  oxbow._core.base.DataSource._scanner
                                     ->  oxbow._core.base.DataSource._source
-                                    <-  'data/malformed.fasta'
+                                    <-  data/malformed.fasta
                                     ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                                     <-  {'compressed': 'False'}
                                 <-  oxbow.core.PyFastaScanner.<object>
@@ -68,7 +70,7 @@ FastaFile("data/malformed.fasta").select(): |-
                             <-  name: string
                                 description: string
                                 sequence: string
-                        <-  oxbow._core.sequence.FastaFile._batch_readers.<locals>.<lambda>
+                        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
                 <-  oxbow._pyarrow.BatchReaderDataset.<object>
             <-  oxbow._pyarrow.BatchReaderDataset.<object>
@@ -84,9 +86,9 @@ FastaFile("data/sample.fasta").select(): |-
                 <-  {'compressed': 'False'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta", None, fields=None, compressed=False, gzi=None, index=None, regions=None)
-                    ->  oxbow._core.sequence.SequenceFile.__init__("data/sample.fasta", None, None, None, None, False)
-                        ->  oxbow._core.base.DataSource.__init__("data/sample.fasta", None, None)
+                ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta, None, fields=None, compressed=False, gzi=None, index=None, regions=None)
+                    ->  oxbow._core.sequence.SequenceFile.__init__(data/sample.fasta, None, None, None, None, False)
+                        ->  oxbow._core.base.DataSource.__init__(data/sample.fasta, None, None)
                         <-  None
                     <-  None
                 <-  None
@@ -96,15 +98,17 @@ FastaFile("data/sample.fasta").select(): |-
                         <-  FastaFile._batch_readers.<generator>
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.fasta'
+                            <-  data/sample.fasta
                             ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         <-  oxbow.core.PyFastaScanner.<object>
+                        ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+                        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                         ->  oxbow._core.sequence.FastaFile._batch_readers.<generator>
                             ->  oxbow._core.base.DataSource.schema
                                 ->  oxbow._core.base.DataSource._scanner
                                     ->  oxbow._core.base.DataSource._source
-                                    <-  'data/sample.fasta'
+                                    <-  data/sample.fasta
                                     ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                                     <-  {'compressed': 'False'}
                                 <-  oxbow.core.PyFastaScanner.<object>
@@ -113,7 +117,7 @@ FastaFile("data/sample.fasta").select(): |-
                             <-  name: string
                                 description: string
                                 sequence: string
-                        <-  oxbow._core.sequence.FastaFile._batch_readers.<locals>.<lambda>
+                        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
                 <-  oxbow._pyarrow.BatchReaderDataset.<object>
             <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_select_regions_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastaFile.test_select_regions_callstack.yaml
@@ -1,18 +1,18 @@
 ? FastaFile("data/sample.fasta", compressed=False).select(index="data/sample.fai",
     gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
 : |-
-    ->  oxbow._core.sequence.FastaFile.select(index="data/sample.fai", gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
-        ->  oxbow._core.sequence.SequenceFile.select(regions=["seq1:10-20", "seq10", "seq2:1-30"], index="data/sample.fai", gzi=None)
-            ->  oxbow._core.base.DataSource.select(gzi=None, index="data/sample.fai", regions=["seq1:10-20", "seq10", "seq2:1-30"])
+    ->  oxbow._core.sequence.FastaFile.select(index=data/sample.fai, gzi=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
+        ->  oxbow._core.sequence.SequenceFile.select(regions=['seq1:10-20', 'seq10', 'seq2:1-30'], index=data/sample.fai, gzi=None)
+            ->  oxbow._core.base.DataSource.select(gzi=None, index=data/sample.fai, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 ->  oxbow._core.sequence.SequenceFile._scan_kwargs
                 <-  {'fields': 'None'}
                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                 <-  {'compressed': 'False'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta", None, fields=None, compressed=False, gzi=None, index="data/sample.fai", regions=["seq1:10-20", "seq10", "seq2:1-30"])
-                    ->  oxbow._core.sequence.SequenceFile.__init__("data/sample.fasta", None, None, "data/sample.fai", None, False)
-                        ->  oxbow._core.base.DataSource.__init__("data/sample.fasta", None, None)
+                ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta, None, fields=None, compressed=False, gzi=None, index=data/sample.fai, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
+                    ->  oxbow._core.sequence.SequenceFile.__init__(data/sample.fasta, None, None, data/sample.fai, None, False)
+                        ->  oxbow._core.base.DataSource.__init__(data/sample.fasta, None, None)
                         <-  None
                     <-  None
                 <-  None
@@ -22,15 +22,17 @@
                         <-  FastaFile._batch_readers.<generator>
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.fasta'
+                            <-  data/sample.fasta
                             ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         <-  oxbow.core.PyFastaScanner.<object>
+                        ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyFastaScanner.scan_query, regions=["seq1:10-20", "seq10", "seq2:1-30"], index=data/sample.fai, gzi=None)>)
+                        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                         ->  oxbow._core.sequence.FastaFile._batch_readers.<generator>
                             ->  oxbow._core.base.DataSource.schema
                                 ->  oxbow._core.base.DataSource._scanner
                                     ->  oxbow._core.base.DataSource._source
-                                    <-  'data/sample.fasta'
+                                    <-  data/sample.fasta
                                     ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                                     <-  {'compressed': 'False'}
                                 <-  oxbow.core.PyFastaScanner.<object>
@@ -39,7 +41,7 @@
                             <-  name: string
                                 description: string
                                 sequence: string
-                        <-  oxbow._core.sequence.FastaFile._batch_readers.<locals>.<lambda>
+                        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
                 <-  oxbow._pyarrow.BatchReaderDataset.<object>
             <-  oxbow._pyarrow.BatchReaderDataset.<object>
@@ -48,16 +50,16 @@
 ? FastaFile("data/sample.fasta", compressed=False).select(index=None, gzi=None, regions=["seq1:10-20",
     "seq10", "seq2:1-30"])
 : |-
-    ->  oxbow._core.sequence.FastaFile.select(index=None, gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
-        ->  oxbow._core.sequence.SequenceFile.select(regions=["seq1:10-20", "seq10", "seq2:1-30"], index=None, gzi=None)
-            ->  oxbow._core.base.DataSource.select(gzi=None, index=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
+    ->  oxbow._core.sequence.FastaFile.select(index=None, gzi=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
+        ->  oxbow._core.sequence.SequenceFile.select(regions=['seq1:10-20', 'seq10', 'seq2:1-30'], index=None, gzi=None)
+            ->  oxbow._core.base.DataSource.select(gzi=None, index=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 ->  oxbow._core.sequence.SequenceFile._scan_kwargs
                 <-  {'fields': 'None'}
                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                 <-  {'compressed': 'False'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta", None, fields=None, compressed=False, gzi=None, index=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
+                ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta, None, fields=None, compressed=False, gzi=None, index=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
             !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
         !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
@@ -65,18 +67,18 @@
 ? FastaFile("data/sample.fasta.gz", compressed=True).select(index="data/sample.fai",
     gzi="data/sample.fasta.gzi", regions=["seq1:10-20", "seq10", "seq2:1-30"])
 : |-
-    ->  oxbow._core.sequence.FastaFile.select(index="data/sample.fai", gzi="data/sample.fasta.gzi", regions=["seq1:10-20", "seq10", "seq2:1-30"])
-        ->  oxbow._core.sequence.SequenceFile.select(regions=["seq1:10-20", "seq10", "seq2:1-30"], index="data/sample.fai", gzi="data/sample.fasta.gzi")
-            ->  oxbow._core.base.DataSource.select(gzi="data/sample.fasta.gzi", index="data/sample.fai", regions=["seq1:10-20", "seq10", "seq2:1-30"])
+    ->  oxbow._core.sequence.FastaFile.select(index=data/sample.fai, gzi=data/sample.fasta.gzi, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
+        ->  oxbow._core.sequence.SequenceFile.select(regions=['seq1:10-20', 'seq10', 'seq2:1-30'], index=data/sample.fai, gzi=data/sample.fasta.gzi)
+            ->  oxbow._core.base.DataSource.select(gzi=data/sample.fasta.gzi, index=data/sample.fai, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 ->  oxbow._core.sequence.SequenceFile._scan_kwargs
                 <-  {'fields': 'None'}
                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                 <-  {'compressed': 'True'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta.gz", None, fields=None, compressed=True, gzi="data/sample.fasta.gzi", index="data/sample.fai", regions=["seq1:10-20", "seq10", "seq2:1-30"])
-                    ->  oxbow._core.sequence.SequenceFile.__init__("data/sample.fasta.gz", None, None, "data/sample.fai", "data/sample.fasta.gzi", True)
-                        ->  oxbow._core.base.DataSource.__init__("data/sample.fasta.gz", None, None)
+                ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta.gz, None, fields=None, compressed=True, gzi=data/sample.fasta.gzi, index=data/sample.fai, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
+                    ->  oxbow._core.sequence.SequenceFile.__init__(data/sample.fasta.gz, None, None, data/sample.fai, data/sample.fasta.gzi, True)
+                        ->  oxbow._core.base.DataSource.__init__(data/sample.fasta.gz, None, None)
                         <-  None
                     <-  None
                 <-  None
@@ -86,15 +88,17 @@
                         <-  FastaFile._batch_readers.<generator>
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.fasta.gz'
+                            <-  data/sample.fasta.gz
                             ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                             <-  {'compressed': 'True'}
                         <-  oxbow.core.PyFastaScanner.<object>
+                        ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyFastaScanner.scan_query, regions=["seq1:10-20", "seq10", "seq2:1-30"], index=data/sample.fai, gzi=data/sample.fasta.gzi)>)
+                        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                         ->  oxbow._core.sequence.FastaFile._batch_readers.<generator>
                             ->  oxbow._core.base.DataSource.schema
                                 ->  oxbow._core.base.DataSource._scanner
                                     ->  oxbow._core.base.DataSource._source
-                                    <-  'data/sample.fasta.gz'
+                                    <-  data/sample.fasta.gz
                                     ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                                     <-  {'compressed': 'True'}
                                 <-  oxbow.core.PyFastaScanner.<object>
@@ -103,7 +107,7 @@
                             <-  name: string
                                 description: string
                                 sequence: string
-                        <-  oxbow._core.sequence.FastaFile._batch_readers.<locals>.<lambda>
+                        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
                 <-  oxbow._pyarrow.BatchReaderDataset.<object>
             <-  oxbow._pyarrow.BatchReaderDataset.<object>
@@ -112,16 +116,16 @@
 ? FastaFile("data/sample.fasta.gz", compressed=True).select(index="data/sample.fai",
     gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
 : |-
-    ->  oxbow._core.sequence.FastaFile.select(index="data/sample.fai", gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
-        ->  oxbow._core.sequence.SequenceFile.select(regions=["seq1:10-20", "seq10", "seq2:1-30"], index="data/sample.fai", gzi=None)
-            ->  oxbow._core.base.DataSource.select(gzi=None, index="data/sample.fai", regions=["seq1:10-20", "seq10", "seq2:1-30"])
+    ->  oxbow._core.sequence.FastaFile.select(index=data/sample.fai, gzi=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
+        ->  oxbow._core.sequence.SequenceFile.select(regions=['seq1:10-20', 'seq10', 'seq2:1-30'], index=data/sample.fai, gzi=None)
+            ->  oxbow._core.base.DataSource.select(gzi=None, index=data/sample.fai, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 ->  oxbow._core.sequence.SequenceFile._scan_kwargs
                 <-  {'fields': 'None'}
                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                 <-  {'compressed': 'True'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta.gz", None, fields=None, compressed=True, gzi=None, index="data/sample.fai", regions=["seq1:10-20", "seq10", "seq2:1-30"])
+                ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta.gz, None, fields=None, compressed=True, gzi=None, index=data/sample.fai, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 !!  ValueError("A GZI index file is required for BGZF-compressed FASTA when regions are specified.")
             !!  ValueError("A GZI index file is required for BGZF-compressed FASTA when regions are specified.")
         !!  ValueError("A GZI index file is required for BGZF-compressed FASTA when regions are specified.")
@@ -129,16 +133,16 @@
 ? FastaFile("data/sample.fasta.gz", compressed=True).select(index=None, gzi="data/sample.fasta.gzi",
     regions=["seq1:10-20", "seq10", "seq2:1-30"])
 : |-
-    ->  oxbow._core.sequence.FastaFile.select(index=None, gzi="data/sample.fasta.gzi", regions=["seq1:10-20", "seq10", "seq2:1-30"])
-        ->  oxbow._core.sequence.SequenceFile.select(regions=["seq1:10-20", "seq10", "seq2:1-30"], index=None, gzi="data/sample.fasta.gzi")
-            ->  oxbow._core.base.DataSource.select(gzi="data/sample.fasta.gzi", index=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
+    ->  oxbow._core.sequence.FastaFile.select(index=None, gzi=data/sample.fasta.gzi, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
+        ->  oxbow._core.sequence.SequenceFile.select(regions=['seq1:10-20', 'seq10', 'seq2:1-30'], index=None, gzi=data/sample.fasta.gzi)
+            ->  oxbow._core.base.DataSource.select(gzi=data/sample.fasta.gzi, index=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 ->  oxbow._core.sequence.SequenceFile._scan_kwargs
                 <-  {'fields': 'None'}
                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                 <-  {'compressed': 'True'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta.gz", None, fields=None, compressed=True, gzi="data/sample.fasta.gzi", index=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
+                ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta.gz, None, fields=None, compressed=True, gzi=data/sample.fasta.gzi, index=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
             !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
         !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
@@ -146,16 +150,16 @@
 ? FastaFile("data/sample.fasta.gz", compressed=True).select(index=None, gzi=None,
     regions=["seq1:10-20", "seq10", "seq2:1-30"])
 : |-
-    ->  oxbow._core.sequence.FastaFile.select(index=None, gzi=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
-        ->  oxbow._core.sequence.SequenceFile.select(regions=["seq1:10-20", "seq10", "seq2:1-30"], index=None, gzi=None)
-            ->  oxbow._core.base.DataSource.select(gzi=None, index=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
+    ->  oxbow._core.sequence.FastaFile.select(index=None, gzi=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
+        ->  oxbow._core.sequence.SequenceFile.select(regions=['seq1:10-20', 'seq10', 'seq2:1-30'], index=None, gzi=None)
+            ->  oxbow._core.base.DataSource.select(gzi=None, index=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 ->  oxbow._core.sequence.SequenceFile._scan_kwargs
                 <-  {'fields': 'None'}
                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                 <-  {'compressed': 'True'}
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
                 <-  {'fields': 'None'}
-                ->  oxbow._core.sequence.FastaFile.__init__("data/sample.fasta.gz", None, fields=None, compressed=True, gzi=None, index=None, regions=["seq1:10-20", "seq10", "seq2:1-30"])
+                ->  oxbow._core.sequence.FastaFile.__init__(data/sample.fasta.gz, None, fields=None, compressed=True, gzi=None, index=None, regions=['seq1:10-20', 'seq10', 'seq2:1-30'])
                 !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
             !!  ValueError("A FAI index file is required for FASTA when regions are specified.")
         !!  ValueError("A FAI index file is required for FASTA when regions are specified.")

--- a/py-oxbow/tests/manifests/test_sequence.TestFastqFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastqFile.test_batches_callstack.yaml
@@ -5,20 +5,22 @@ FastqFile("data/sample.fastq", fields=('name', 'sequence')).batches(batch_size=5
     <-  FastqFile._batch_readers.<generator>
     ->  oxbow._core.base.DataSource._scanner
         ->  oxbow._core.base.DataSource._source
-        <-  'data/sample.fastq'
+        <-  data/sample.fastq
         ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
         <-  {'compressed': 'False'}
     <-  oxbow.core.PyFastqScanner.<object>
+    ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     ->  oxbow._core.sequence.FastqFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource.schema
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.fastq'
+                <-  data/sample.fastq
                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                 <-  {'compressed': 'False'}
             <-  oxbow.core.PyFastqScanner.<object>
             ->  oxbow._core.sequence.SequenceFile._schema_kwargs
-            <-  {'fields': ("'name'", "'sequence'")}
+            <-  {'fields': ('name', 'sequence')}
         <-  name: string
             sequence: string
         ->  oxbow._core.base.DataSource.batches.<generator>
@@ -49,4 +51,4 @@ FastqFile("data/sample.fastq", fields=('name', 'sequence')).batches(batch_size=5
             ----
             name: ["seq16","seq17","seq18","seq19","seq20"]
             sequence: ["GCATGCATGCATGCATGCATGCATGCATGCATGCATGC","ATCGATCGATCGATCGATCGATCGATCGATCGATCGAT","CTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTA","GATCGATCGATCGATCGATCGATCGATCGATCGATCGAT","TACGTACGTACGTACGTACGTACGTACGTACGTACGTAC"]
-    <-  oxbow._core.sequence.FastqFile._batch_readers.<locals>.<lambda>
+    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader

--- a/py-oxbow/tests/manifests/test_sequence.TestFastqFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastqFile.test_fragments_callstack.yaml
@@ -4,21 +4,23 @@ FastqFile("data/sample.fastq", fields=('name', 'sequence')).fragments(batch_size
         <-  FastqFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.fastq'
+            <-  data/sample.fastq
             ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyFastqScanner.<object>
+        ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.sequence.FastqFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.fastq'
+                    <-  data/sample.fastq
                     ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  oxbow.core.PyFastqScanner.<object>
                 ->  oxbow._core.sequence.SequenceFile._schema_kwargs
-                <-  {'fields': ("'name'", "'sequence'")}
+                <-  {'fields': ('name', 'sequence')}
             <-  name: string
                 sequence: string
-        <-  oxbow._core.sequence.FastqFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_sequence.TestFastqFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastqFile.test_init_callstack.yaml
@@ -1,15 +1,15 @@
 FastqFile("data/does-not-exist.fastq"): |-
-    ->  oxbow._core.sequence.SequenceFile.__init__("data/does-not-exist.fastq")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.fastq", None, None)
+    ->  oxbow._core.sequence.SequenceFile.__init__(data/does-not-exist.fastq)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.fastq, None, None)
         <-  None
     <-  None
 FastqFile("data/malformed.fastq"): |-
-    ->  oxbow._core.sequence.SequenceFile.__init__("data/malformed.fastq")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.fastq", None, None)
+    ->  oxbow._core.sequence.SequenceFile.__init__(data/malformed.fastq)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.fastq, None, None)
         <-  None
     <-  None
 FastqFile("data/sample.fastq"): |-
-    ->  oxbow._core.sequence.SequenceFile.__init__("data/sample.fastq")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.fastq", None, None)
+    ->  oxbow._core.sequence.SequenceFile.__init__(data/sample.fastq)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.fastq, None, None)
         <-  None
     <-  None

--- a/py-oxbow/tests/manifests/test_sequence.TestFastqFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_sequence.TestFastqFile.test_select_callstack.yaml
@@ -7,8 +7,8 @@ FastqFile("data/does-not-exist.fastq").select(): |-
             <-  {'compressed': 'False'}
             ->  oxbow._core.sequence.SequenceFile._schema_kwargs
             <-  {'fields': 'None'}
-            ->  oxbow._core.sequence.SequenceFile.__init__("data/does-not-exist.fastq", None, fields=None, compressed=False, gzi=None, index=None)
-                ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.fastq", None, None)
+            ->  oxbow._core.sequence.SequenceFile.__init__(data/does-not-exist.fastq, None, fields=None, compressed=False, gzi=None, index=None)
+                ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.fastq, None, None)
                 <-  None
             <-  None
             ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -17,7 +17,7 @@ FastqFile("data/does-not-exist.fastq").select(): |-
                     <-  FastqFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/does-not-exist.fastq'
+                        <-  data/does-not-exist.fastq
                         ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                         <-  {'compressed': 'False'}
                     !!  FileNotFoundError('No such file or directory (os error 2)')
@@ -34,8 +34,8 @@ FastqFile("data/malformed.fastq").select(): |-
             <-  {'compressed': 'False'}
             ->  oxbow._core.sequence.SequenceFile._schema_kwargs
             <-  {'fields': 'None'}
-            ->  oxbow._core.sequence.SequenceFile.__init__("data/malformed.fastq", None, fields=None, compressed=False, gzi=None, index=None)
-                ->  oxbow._core.base.DataSource.__init__("data/malformed.fastq", None, None)
+            ->  oxbow._core.sequence.SequenceFile.__init__(data/malformed.fastq, None, fields=None, compressed=False, gzi=None, index=None)
+                ->  oxbow._core.base.DataSource.__init__(data/malformed.fastq, None, None)
                 <-  None
             <-  None
             ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -44,15 +44,17 @@ FastqFile("data/malformed.fastq").select(): |-
                     <-  FastqFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/malformed.fastq'
+                        <-  data/malformed.fastq
                         ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                         <-  {'compressed': 'False'}
                     <-  oxbow.core.PyFastqScanner.<object>
+                    ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+                    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                     ->  oxbow._core.sequence.FastqFile._batch_readers.<generator>
                         ->  oxbow._core.base.DataSource.schema
                             ->  oxbow._core.base.DataSource._scanner
                                 ->  oxbow._core.base.DataSource._source
-                                <-  'data/malformed.fastq'
+                                <-  data/malformed.fastq
                                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                                 <-  {'compressed': 'False'}
                             <-  oxbow.core.PyFastqScanner.<object>
@@ -62,7 +64,7 @@ FastqFile("data/malformed.fastq").select(): |-
                             description: string
                             sequence: string
                             quality: string
-                    <-  oxbow._core.sequence.FastqFile._batch_readers.<locals>.<lambda>
+                    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
             <-  oxbow._pyarrow.BatchReaderDataset.<object>
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
@@ -76,8 +78,8 @@ FastqFile("data/sample.fastq").select(): |-
             <-  {'compressed': 'False'}
             ->  oxbow._core.sequence.SequenceFile._schema_kwargs
             <-  {'fields': 'None'}
-            ->  oxbow._core.sequence.SequenceFile.__init__("data/sample.fastq", None, fields=None, compressed=False, gzi=None, index=None)
-                ->  oxbow._core.base.DataSource.__init__("data/sample.fastq", None, None)
+            ->  oxbow._core.sequence.SequenceFile.__init__(data/sample.fastq, None, fields=None, compressed=False, gzi=None, index=None)
+                ->  oxbow._core.base.DataSource.__init__(data/sample.fastq, None, None)
                 <-  None
             <-  None
             ->  oxbow._core.base.DataSource.dataset(batch_size=131072)
@@ -86,15 +88,17 @@ FastqFile("data/sample.fastq").select(): |-
                     <-  FastqFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource._scanner
                         ->  oxbow._core.base.DataSource._source
-                        <-  'data/sample.fastq'
+                        <-  data/sample.fastq
                         ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                         <-  {'compressed': 'False'}
                     <-  oxbow.core.PyFastqScanner.<object>
+                    ->  oxbow._core.base.DataSource._make_batch_reader(builtins.builtin_function_or_method.<object>)
+                    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                     ->  oxbow._core.sequence.FastqFile._batch_readers.<generator>
                         ->  oxbow._core.base.DataSource.schema
                             ->  oxbow._core.base.DataSource._scanner
                                 ->  oxbow._core.base.DataSource._source
-                                <-  'data/sample.fastq'
+                                <-  data/sample.fastq
                                 ->  oxbow._core.sequence.SequenceFile._scanner_kwargs
                                 <-  {'compressed': 'False'}
                             <-  oxbow.core.PyFastqScanner.<object>
@@ -104,7 +108,7 @@ FastqFile("data/sample.fastq").select(): |-
                             description: string
                             sequence: string
                             quality: string
-                    <-  oxbow._core.sequence.FastqFile._batch_readers.<locals>.<lambda>
+                    <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
             <-  oxbow._pyarrow.BatchReaderDataset.<object>
         <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_variant.TestBcfFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_variant.TestBcfFile.test_batches_callstack.yaml
@@ -1,25 +1,25 @@
 ? BcfFile("data/sample.bcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",),
     info_fields=("DP",)).fragments(batch_size=3)
 : |-
-    ->  oxbow._core.variant.BcfFile.__init__("data/sample.bcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",), info_fields=("DP",))
-        ->  oxbow._core.variant.VariantFile.__init__(uri="data/sample.bcf", opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=("DP",), genotype_fields=("GT",), samples=("HG00096", "HG00101", "HG00103"), genotype_by="sample")
-            ->  oxbow._core.base.DataSource.__init__("data/sample.bcf", None, None)
+    ->  oxbow._core.variant.BcfFile.__init__(data/sample.bcf, samples=('HG00096', 'HG00101', 'HG00103'), genotype_fields=('GT',), info_fields=('DP',))
+        ->  oxbow._core.variant.VariantFile.__init__(uri=data/sample.bcf, opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=('DP',), genotype_fields=('GT',), samples=('HG00096', 'HG00101', 'HG00103'), genotype_by=sample)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.bcf, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>

--- a/py-oxbow/tests/manifests/test_variant.TestBcfFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_variant.TestBcfFile.test_fragments_callstack.yaml
@@ -4,22 +4,24 @@ BcfFile("data/sample.bcf", samples=('HG00096', 'HG00101', 'HG00103')).fragments(
         <-  VariantFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.bcf'
+            <-  data/sample.bcf
             ->  oxbow._core.variant.BcfFile._scanner_kwargs
             <-  {}
         <-  oxbow.core.PyBcfScanner.<object>
         ->  oxbow._core.variant.VariantFile._scan_kwargs
-        <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'", "'CN'", "'CNL'", "'CNP'", "'CNQ'", "'GP'", "'GQ'", "'FT'", "'PL'"], 'info_fields': ["'DP'", "'END'", "'SVTYPE'", "'AA'", "'AC'", "'AF'", "'NS'", "'AN'", "'SAS_AF'", "'EUR_AF'", '<', '3', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+        <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT', 'CN', 'CNL', 'CNP', 'CNQ', 'GP', 'GQ', 'FT', 'PL'], 'info_fields': ['DP', 'END', 'SVTYPE', 'AA', 'AC', 'AF', 'NS', 'AN', 'SAS_AF', 'EUR_AF', '<', '3', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
+        ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyBcfScanner.scan, fields=None, genotype_by=sample, genotype_fields=["GT", "CN", "CNL", "CNP", "CNQ", "GP", "GQ", "FT", "PL"], info_fields=["DP", "END", "SVTYPE", "AA", "AC", "AF", "NS", "AN", "SAS_AF", "EUR_AF", "<", "3", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], samples=["HG00096", "HG00101", "HG00103"])>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.variant.VariantFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bcf'
+                    <-  data/sample.bcf
                     ->  oxbow._core.variant.BcfFile._scanner_kwargs
                     <-  {}
                 <-  oxbow.core.PyBcfScanner.<object>
                 ->  oxbow._core.variant.VariantFile._schema_kwargs
-                <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'", "'CN'", "'CNL'", "'CNP'", "'CNQ'", "'GP'", "'GQ'", "'FT'", "'PL'"], 'info_fields': ["'DP'", "'END'", "'SVTYPE'", "'AA'", "'AC'", "'AF'", "'NS'", "'AN'", "'SAS_AF'", "'EUR_AF'", '<', '3', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+                <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT', 'CN', 'CNL', 'CNP', 'CNQ', 'GP', 'GQ', 'FT', 'PL'], 'info_fields': ['DP', 'END', 'SVTYPE', 'AA', 'AC', 'AF', 'NS', 'AN', 'SAS_AF', 'EUR_AF', '<', '3', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
             <-  chrom: dictionary<values=string, indices=int32, ordered=0>
                 pos: int32
                 id: list<item: string>
@@ -105,5 +107,5 @@ BcfFile("data/sample.bcf", samples=('HG00096', 'HG00101', 'HG00103')).fragments(
                   child 7, FT: string
                   child 8, PL: list<item: int32>
                       child 0, item: int32
-        <-  oxbow._core.variant.VariantFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_variant.TestBcfFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_variant.TestBcfFile.test_init_callstack.yaml
@@ -1,49 +1,49 @@
 BcfFile("data/does-not-exist.bcf"): |-
-    ->  oxbow._core.variant.BcfFile.__init__("data/does-not-exist.bcf")
-        ->  oxbow._core.variant.VariantFile.__init__(uri="data/does-not-exist.bcf", opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=None, genotype_fields=None, samples=None, genotype_by="sample")
-            ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bcf", None, None)
+    ->  oxbow._core.variant.BcfFile.__init__(data/does-not-exist.bcf)
+        ->  oxbow._core.variant.VariantFile.__init__(uri=data/does-not-exist.bcf, opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=None, genotype_fields=None, samples=None, genotype_by=sample)
+            ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bcf, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/does-not-exist.bcf'
+                <-  data/does-not-exist.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             !!  FileNotFoundError('No such file or directory (os error 2)')
         !!  FileNotFoundError("No such file or directory (os error 2)")
     !!  FileNotFoundError("No such file or directory (os error 2)")
 BcfFile("data/malformed.bcf"): |-
-    ->  oxbow._core.variant.BcfFile.__init__("data/malformed.bcf")
-        ->  oxbow._core.variant.VariantFile.__init__(uri="data/malformed.bcf", opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=None, genotype_fields=None, samples=None, genotype_by="sample")
-            ->  oxbow._core.base.DataSource.__init__("data/malformed.bcf", None, None)
+    ->  oxbow._core.variant.BcfFile.__init__(data/malformed.bcf)
+        ->  oxbow._core.variant.VariantFile.__init__(uri=data/malformed.bcf, opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=None, genotype_fields=None, samples=None, genotype_by=sample)
+            ->  oxbow._core.base.DataSource.__init__(data/malformed.bcf, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/malformed.bcf'
+                <-  data/malformed.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             !!  OSError('invalid BGZF header')
         !!  OSError("invalid BGZF header")
     !!  OSError("invalid BGZF header")
 BcfFile("data/sample.bcf"): |-
-    ->  oxbow._core.variant.BcfFile.__init__("data/sample.bcf")
-        ->  oxbow._core.variant.VariantFile.__init__(uri="data/sample.bcf", opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=None, genotype_fields=None, samples=None, genotype_by="sample")
-            ->  oxbow._core.base.DataSource.__init__("data/sample.bcf", None, None)
+    ->  oxbow._core.variant.BcfFile.__init__(data/sample.bcf)
+        ->  oxbow._core.variant.VariantFile.__init__(uri=data/sample.bcf, opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=None, genotype_fields=None, samples=None, genotype_by=sample)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.bcf, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>

--- a/py-oxbow/tests/manifests/test_variant.TestBcfFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_variant.TestBcfFile.test_select_callstack.yaml
@@ -1,49 +1,49 @@
 BcfFile("data/does-not-exist.bcf").select(): |-
-    ->  oxbow._core.variant.BcfFile.__init__("data/does-not-exist.bcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",), info_fields=("DP",))
-        ->  oxbow._core.variant.VariantFile.__init__(uri="data/does-not-exist.bcf", opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=("DP",), genotype_fields=("GT",), samples=("HG00096", "HG00101", "HG00103"), genotype_by="sample")
-            ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.bcf", None, None)
+    ->  oxbow._core.variant.BcfFile.__init__(data/does-not-exist.bcf, samples=('HG00096', 'HG00101', 'HG00103'), genotype_fields=('GT',), info_fields=('DP',))
+        ->  oxbow._core.variant.VariantFile.__init__(uri=data/does-not-exist.bcf, opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=('DP',), genotype_fields=('GT',), samples=('HG00096', 'HG00101', 'HG00103'), genotype_by=sample)
+            ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.bcf, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/does-not-exist.bcf'
+                <-  data/does-not-exist.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             !!  FileNotFoundError('No such file or directory (os error 2)')
         !!  FileNotFoundError("No such file or directory (os error 2)")
     !!  FileNotFoundError("No such file or directory (os error 2)")
 BcfFile("data/malformed.bcf").select(): |-
-    ->  oxbow._core.variant.BcfFile.__init__("data/malformed.bcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",), info_fields=("DP",))
-        ->  oxbow._core.variant.VariantFile.__init__(uri="data/malformed.bcf", opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=("DP",), genotype_fields=("GT",), samples=("HG00096", "HG00101", "HG00103"), genotype_by="sample")
-            ->  oxbow._core.base.DataSource.__init__("data/malformed.bcf", None, None)
+    ->  oxbow._core.variant.BcfFile.__init__(data/malformed.bcf, samples=('HG00096', 'HG00101', 'HG00103'), genotype_fields=('GT',), info_fields=('DP',))
+        ->  oxbow._core.variant.VariantFile.__init__(uri=data/malformed.bcf, opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=('DP',), genotype_fields=('GT',), samples=('HG00096', 'HG00101', 'HG00103'), genotype_by=sample)
+            ->  oxbow._core.base.DataSource.__init__(data/malformed.bcf, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/malformed.bcf'
+                <-  data/malformed.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             !!  OSError('invalid BGZF header')
         !!  OSError("invalid BGZF header")
     !!  OSError("invalid BGZF header")
 BcfFile("data/sample.bcf").select(): |-
-    ->  oxbow._core.variant.BcfFile.__init__("data/sample.bcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",), info_fields=("DP",))
-        ->  oxbow._core.variant.VariantFile.__init__(uri="data/sample.bcf", opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=("DP",), genotype_fields=("GT",), samples=("HG00096", "HG00101", "HG00103"), genotype_by="sample")
-            ->  oxbow._core.base.DataSource.__init__("data/sample.bcf", None, None)
+    ->  oxbow._core.variant.BcfFile.__init__(data/sample.bcf, samples=('HG00096', 'HG00101', 'HG00103'), genotype_fields=('GT',), info_fields=('DP',))
+        ->  oxbow._core.variant.VariantFile.__init__(uri=data/sample.bcf, opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=('DP',), genotype_fields=('GT',), samples=('HG00096', 'HG00101', 'HG00103'), genotype_by=sample)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.bcf, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.bcf'
+                <-  data/sample.bcf
                 ->  oxbow._core.variant.BcfFile._scanner_kwargs
                 <-  {}
             <-  oxbow.core.PyBcfScanner.<object>
@@ -51,30 +51,30 @@ BcfFile("data/sample.bcf").select(): |-
     <-  None
     ->  oxbow._core.base.DataSource.select()
         ->  oxbow._core.variant.VariantFile._scan_kwargs
-        <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'"], 'info_fields': ["'DP'"], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+        <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT'], 'info_fields': ['DP'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
         ->  oxbow._core.variant.BcfFile._scanner_kwargs
         <-  {}
         ->  oxbow._core.variant.VariantFile._schema_kwargs
-        <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'"], 'info_fields': ["'DP'"], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
-        ->  oxbow._core.variant.BcfFile.__init__("data/sample.bcf", None, fields=None, genotype_by="sample", genotype_fields=["GT"], info_fields=["DP"], samples=["HG00096", "HG00101", "HG00103"])
-            ->  oxbow._core.variant.VariantFile.__init__(uri="data/sample.bcf", opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=["DP"], genotype_fields=["GT"], samples=["HG00096", "HG00101", "HG00103"], genotype_by="sample")
-                ->  oxbow._core.base.DataSource.__init__("data/sample.bcf", None, None)
+        <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT'], 'info_fields': ['DP'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
+        ->  oxbow._core.variant.BcfFile.__init__(data/sample.bcf, None, fields=None, genotype_by=sample, genotype_fields=['GT'], info_fields=['DP'], samples=['HG00096', 'HG00101', 'HG00103'])
+            ->  oxbow._core.variant.VariantFile.__init__(uri=data/sample.bcf, opener=None, fields=None, index=None, compressed=True, regions=None, info_fields=['DP'], genotype_fields=['GT'], samples=['HG00096', 'HG00101', 'HG00103'], genotype_by=sample)
+                ->  oxbow._core.base.DataSource.__init__(data/sample.bcf, None, None)
                 <-  None
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bcf'
+                    <-  data/sample.bcf
                     ->  oxbow._core.variant.BcfFile._scanner_kwargs
                     <-  {}
                 <-  oxbow.core.PyBcfScanner.<object>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bcf'
+                    <-  data/sample.bcf
                     ->  oxbow._core.variant.BcfFile._scanner_kwargs
                     <-  {}
                 <-  oxbow.core.PyBcfScanner.<object>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bcf'
+                    <-  data/sample.bcf
                     ->  oxbow._core.variant.BcfFile._scanner_kwargs
                     <-  {}
                 <-  oxbow.core.PyBcfScanner.<object>
@@ -86,22 +86,24 @@ BcfFile("data/sample.bcf").select(): |-
                 <-  VariantFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.bcf'
+                    <-  data/sample.bcf
                     ->  oxbow._core.variant.BcfFile._scanner_kwargs
                     <-  {}
                 <-  oxbow.core.PyBcfScanner.<object>
                 ->  oxbow._core.variant.VariantFile._scan_kwargs
-                <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'"], 'info_fields': ["'DP'"], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+                <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT'], 'info_fields': ['DP'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
+                ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyBcfScanner.scan, fields=None, genotype_by=sample, genotype_fields=["GT"], info_fields=["DP"], samples=["HG00096", "HG00101", "HG00103"])>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.variant.VariantFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.bcf'
+                            <-  data/sample.bcf
                             ->  oxbow._core.variant.BcfFile._scanner_kwargs
                             <-  {}
                         <-  oxbow.core.PyBcfScanner.<object>
                         ->  oxbow._core.variant.VariantFile._schema_kwargs
-                        <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'"], 'info_fields': ["'DP'"], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+                        <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT'], 'info_fields': ['DP'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
                     <-  chrom: dictionary<values=string, indices=int32, ordered=0>
                         pos: int32
                         id: list<item: string>
@@ -132,7 +134,7 @@ BcfFile("data/sample.bcf").select(): |-
                                   child 0, item: int32
                               child 1, phased: list<item: bool>
                                   child 0, item: bool
-                <-  oxbow._core.variant.VariantFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/manifests/test_variant.TestVcfFile.test_batches_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_variant.TestVcfFile.test_batches_callstack.yaml
@@ -1,24 +1,24 @@
 ? VcfFile("data/sample.vcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",),
     info_fields=("DP",)).fragments(batch_size=3)
 : |-
-    ->  oxbow._core.variant.VariantFile.__init__("data/sample.vcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",), info_fields=("DP",))
-        ->  oxbow._core.base.DataSource.__init__("data/sample.vcf", None, None)
+    ->  oxbow._core.variant.VariantFile.__init__(data/sample.vcf, samples=('HG00096', 'HG00101', 'HG00103'), genotype_fields=('GT',), info_fields=('DP',))
+        ->  oxbow._core.base.DataSource.__init__(data/sample.vcf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>

--- a/py-oxbow/tests/manifests/test_variant.TestVcfFile.test_fragments_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_variant.TestVcfFile.test_fragments_callstack.yaml
@@ -4,22 +4,24 @@ VcfFile("data/sample.vcf", samples=('HG00096', 'HG00101', 'HG00103')).fragments(
         <-  VariantFile._batch_readers.<generator>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>
         ->  oxbow._core.variant.VariantFile._scan_kwargs
-        <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'", "'CN'", "'CNL'", "'CNP'", "'CNQ'", "'GP'", "'GQ'", "'FT'", "'PL'"], 'info_fields': ["'DP'", "'END'", "'SVTYPE'", "'AA'", "'AC'", "'AF'", "'NS'", "'AN'", "'SAS_AF'", "'EUR_AF'", '<', '3', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+        <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT', 'CN', 'CNL', 'CNP', 'CNQ', 'GP', 'GQ', 'FT', 'PL'], 'info_fields': ['DP', 'END', 'SVTYPE', 'AA', 'AC', 'AF', 'NS', 'AN', 'SAS_AF', 'EUR_AF', '<', '3', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
+        ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyVcfScanner.scan, fields=None, genotype_by=sample, genotype_fields=["GT", "CN", "CNL", "CNP", "CNQ", "GP", "GQ", "FT", "PL"], info_fields=["DP", "END", "SVTYPE", "AA", "AC", "AF", "NS", "AN", "SAS_AF", "EUR_AF", "<", "3", " ", "m", "o", "r", "e", " ", "i", "t", "e", "m", "s", ">"], samples=["HG00096", "HG00101", "HG00103"])>)
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
         ->  oxbow._core.variant.VariantFile._batch_readers.<generator>
             ->  oxbow._core.base.DataSource.schema
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.vcf'
+                    <-  data/sample.vcf
                     ->  oxbow._core.variant.VariantFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  oxbow.core.PyVcfScanner.<object>
                 ->  oxbow._core.variant.VariantFile._schema_kwargs
-                <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'", "'CN'", "'CNL'", "'CNP'", "'CNQ'", "'GP'", "'GQ'", "'FT'", "'PL'"], 'info_fields': ["'DP'", "'END'", "'SVTYPE'", "'AA'", "'AC'", "'AF'", "'NS'", "'AN'", "'SAS_AF'", "'EUR_AF'", '<', '3', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+                <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT', 'CN', 'CNL', 'CNP', 'CNQ', 'GP', 'GQ', 'FT', 'PL'], 'info_fields': ['DP', 'END', 'SVTYPE', 'AA', 'AC', 'AF', 'NS', 'AN', 'SAS_AF', 'EUR_AF', '<', '3', ' ', 'm', 'o', 'r', 'e', ' ', 'i', 't', 'e', 'm', 's', '>'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
             <-  chrom: dictionary<values=string, indices=int32, ordered=0>
                 pos: int32
                 id: list<item: string>
@@ -105,5 +107,5 @@ VcfFile("data/sample.vcf", samples=('HG00096', 'HG00101', 'HG00103')).fragments(
                   child 7, FT: string
                   child 8, PL: list<item: int32>
                       child 0, item: int32
-        <-  oxbow._core.variant.VariantFile._batch_readers.<locals>.<lambda>
+        <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
     <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']

--- a/py-oxbow/tests/manifests/test_variant.TestVcfFile.test_init_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_variant.TestVcfFile.test_init_callstack.yaml
@@ -1,44 +1,44 @@
 VcfFile("data/does-not-exist.vcf"): |-
-    ->  oxbow._core.variant.VariantFile.__init__("data/does-not-exist.vcf")
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.vcf", None, None)
+    ->  oxbow._core.variant.VariantFile.__init__(data/does-not-exist.vcf)
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.vcf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/does-not-exist.vcf'
+            <-  data/does-not-exist.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  FileNotFoundError('No such file or directory (os error 2)')
     !!  FileNotFoundError("No such file or directory (os error 2)")
 VcfFile("data/malformed.vcf"): |-
-    ->  oxbow._core.variant.VariantFile.__init__("data/malformed.vcf")
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.vcf", None, None)
+    ->  oxbow._core.variant.VariantFile.__init__(data/malformed.vcf)
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.vcf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/malformed.vcf'
+            <-  data/malformed.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  FileNotFoundError('No such file or directory (os error 2)')
     !!  FileNotFoundError("No such file or directory (os error 2)")
 VcfFile("data/sample.vcf"): |-
-    ->  oxbow._core.variant.VariantFile.__init__("data/sample.vcf")
-        ->  oxbow._core.base.DataSource.__init__("data/sample.vcf", None, None)
+    ->  oxbow._core.variant.VariantFile.__init__(data/sample.vcf)
+        ->  oxbow._core.base.DataSource.__init__(data/sample.vcf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>

--- a/py-oxbow/tests/manifests/test_variant.TestVcfFile.test_select_callstack.yaml
+++ b/py-oxbow/tests/manifests/test_variant.TestVcfFile.test_select_callstack.yaml
@@ -1,12 +1,12 @@
 ? VcfFile("data/does-not-exist.vcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",),
     info_fields=("DP",)).select()
 : |-
-    ->  oxbow._core.variant.VariantFile.__init__("data/does-not-exist.vcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",), info_fields=("DP",))
-        ->  oxbow._core.base.DataSource.__init__("data/does-not-exist.vcf", None, None)
+    ->  oxbow._core.variant.VariantFile.__init__(data/does-not-exist.vcf, samples=('HG00096', 'HG00101', 'HG00103'), genotype_fields=('GT',), info_fields=('DP',))
+        ->  oxbow._core.base.DataSource.__init__(data/does-not-exist.vcf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/does-not-exist.vcf'
+            <-  data/does-not-exist.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  FileNotFoundError('No such file or directory (os error 2)')
@@ -14,12 +14,12 @@
 ? VcfFile("data/malformed.vcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",),
     info_fields=("DP",)).select()
 : |-
-    ->  oxbow._core.variant.VariantFile.__init__("data/malformed.vcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",), info_fields=("DP",))
-        ->  oxbow._core.base.DataSource.__init__("data/malformed.vcf", None, None)
+    ->  oxbow._core.variant.VariantFile.__init__(data/malformed.vcf, samples=('HG00096', 'HG00101', 'HG00103'), genotype_fields=('GT',), info_fields=('DP',))
+        ->  oxbow._core.base.DataSource.__init__(data/malformed.vcf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/malformed.vcf'
+            <-  data/malformed.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         !!  FileNotFoundError('No such file or directory (os error 2)')
@@ -27,53 +27,53 @@
 ? VcfFile("data/sample.vcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",),
     info_fields=("DP",)).select()
 : |-
-    ->  oxbow._core.variant.VariantFile.__init__("data/sample.vcf", samples=("HG00096", "HG00101", "HG00103"), genotype_fields=("GT",), info_fields=("DP",))
-        ->  oxbow._core.base.DataSource.__init__("data/sample.vcf", None, None)
+    ->  oxbow._core.variant.VariantFile.__init__(data/sample.vcf, samples=('HG00096', 'HG00101', 'HG00103'), genotype_fields=('GT',), info_fields=('DP',))
+        ->  oxbow._core.base.DataSource.__init__(data/sample.vcf, None, None)
         <-  None
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>
         ->  oxbow._core.base.DataSource._scanner
             ->  oxbow._core.base.DataSource._source
-            <-  'data/sample.vcf'
+            <-  data/sample.vcf
             ->  oxbow._core.variant.VariantFile._scanner_kwargs
             <-  {'compressed': 'False'}
         <-  oxbow.core.PyVcfScanner.<object>
     <-  None
     ->  oxbow._core.base.DataSource.select()
         ->  oxbow._core.variant.VariantFile._scan_kwargs
-        <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'"], 'info_fields': ["'DP'"], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+        <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT'], 'info_fields': ['DP'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
         ->  oxbow._core.variant.VariantFile._scanner_kwargs
         <-  {'compressed': 'False'}
         ->  oxbow._core.variant.VariantFile._schema_kwargs
-        <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'"], 'info_fields': ["'DP'"], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
-        ->  oxbow._core.variant.VariantFile.__init__("data/sample.vcf", None, fields=None, genotype_by="sample", genotype_fields=["GT"], info_fields=["DP"], samples=["HG00096", "HG00101", "HG00103"], compressed=False)
-            ->  oxbow._core.base.DataSource.__init__("data/sample.vcf", None, None)
+        <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT'], 'info_fields': ['DP'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
+        ->  oxbow._core.variant.VariantFile.__init__(data/sample.vcf, None, fields=None, genotype_by=sample, genotype_fields=['GT'], info_fields=['DP'], samples=['HG00096', 'HG00101', 'HG00103'], compressed=False)
+            ->  oxbow._core.base.DataSource.__init__(data/sample.vcf, None, None)
             <-  None
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.vcf'
+                <-  data/sample.vcf
                 ->  oxbow._core.variant.VariantFile._scanner_kwargs
                 <-  {'compressed': 'False'}
             <-  oxbow.core.PyVcfScanner.<object>
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.vcf'
+                <-  data/sample.vcf
                 ->  oxbow._core.variant.VariantFile._scanner_kwargs
                 <-  {'compressed': 'False'}
             <-  oxbow.core.PyVcfScanner.<object>
             ->  oxbow._core.base.DataSource._scanner
                 ->  oxbow._core.base.DataSource._source
-                <-  'data/sample.vcf'
+                <-  data/sample.vcf
                 ->  oxbow._core.variant.VariantFile._scanner_kwargs
                 <-  {'compressed': 'False'}
             <-  oxbow.core.PyVcfScanner.<object>
@@ -84,22 +84,24 @@
                 <-  VariantFile._batch_readers.<generator>
                 ->  oxbow._core.base.DataSource._scanner
                     ->  oxbow._core.base.DataSource._source
-                    <-  'data/sample.vcf'
+                    <-  data/sample.vcf
                     ->  oxbow._core.variant.VariantFile._scanner_kwargs
                     <-  {'compressed': 'False'}
                 <-  oxbow.core.PyVcfScanner.<object>
                 ->  oxbow._core.variant.VariantFile._scan_kwargs
-                <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'"], 'info_fields': ["'DP'"], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+                <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT'], 'info_fields': ['DP'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
+                ->  oxbow._core.base.DataSource._make_batch_reader(functools.partial(builtins.PyVcfScanner.scan, fields=None, genotype_by=sample, genotype_fields=["GT"], info_fields=["DP"], samples=["HG00096", "HG00101", "HG00103"])>)
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
                 ->  oxbow._core.variant.VariantFile._batch_readers.<generator>
                     ->  oxbow._core.base.DataSource.schema
                         ->  oxbow._core.base.DataSource._scanner
                             ->  oxbow._core.base.DataSource._source
-                            <-  'data/sample.vcf'
+                            <-  data/sample.vcf
                             ->  oxbow._core.variant.VariantFile._scanner_kwargs
                             <-  {'compressed': 'False'}
                         <-  oxbow.core.PyVcfScanner.<object>
                         ->  oxbow._core.variant.VariantFile._schema_kwargs
-                        <-  {'fields': 'None', 'genotype_by': "'sample'", 'genotype_fields': ["'GT'"], 'info_fields': ["'DP'"], 'samples': ["'HG00096'", "'HG00101'", "'HG00103'"]}
+                        <-  {'fields': 'None', 'genotype_by': 'sample', 'genotype_fields': ['GT'], 'info_fields': ['DP'], 'samples': ['HG00096', 'HG00101', 'HG00103']}
                     <-  chrom: dictionary<values=string, indices=int32, ordered=0>
                         pos: int32
                         id: list<item: string>
@@ -130,7 +132,7 @@
                                   child 0, item: int32
                               child 1, phased: list<item: bool>
                                   child 0, item: bool
-                <-  oxbow._core.variant.VariantFile._batch_readers.<locals>.<lambda>
+                <-  oxbow._core.base.DataSource._make_batch_reader.<locals>._batch_reader
             <-  ['oxbow._pyarrow.BatchReaderFragment.<object>']
         <-  oxbow._pyarrow.BatchReaderDataset.<object>
     <-  oxbow._pyarrow.BatchReaderDataset.<object>

--- a/py-oxbow/tests/test_alignment.py
+++ b/py-oxbow/tests/test_alignment.py
@@ -79,8 +79,12 @@ class TestBamFile:
             fragment.iter_batches()
         assert len(fragments) == expected_count
         if regions is not None and regions != ("*",):
-            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
-            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+            assert (
+                mock_scanner_type.return_value.scan_query.call_count == expected_count
+            )
+            for call, region in zip(
+                mock_scanner_type.return_value.scan_query.mock_calls, regions
+            ):
                 assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
@@ -180,10 +184,13 @@ class TestSamFile:
             fragment.iter_batches()
         assert len(fragments) == expected_count
         if regions is not None and regions != ("*",):
-            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
-            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+            assert (
+                mock_scanner_type.return_value.scan_query.call_count == expected_count
+            )
+            for call, region in zip(
+                mock_scanner_type.return_value.scan_query.mock_calls, regions
+            ):
                 assert call.kwargs["region"] == region
-
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),

--- a/py-oxbow/tests/test_feature.py
+++ b/py-oxbow/tests/test_feature.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from pytest_manifest import Manifest
 
@@ -71,9 +73,20 @@ class TestBedFile:
         "regions",
         [("foo",), ("foo", "bar"), ("foo", "bar", "baz"), ("*",), None],
     )
-    def test_fragments(self, regions):
-        fragments = ox.BedFile("data/sample.bed", regions=regions).fragments()
-        assert len(fragments) == (len(regions) if regions else 1)
+    @mock.patch("oxbow._core.base.pa.RecordBatchReader")
+    def test_fragments(self, _, regions, mocker):
+        expected_count = 1 if regions is None else len(regions)
+        ds = ox.BedFile("data/sample.bed", regions=regions)
+        mock_scanner_type = mocker.patch.object(ds, "_scanner_type")
+        mock_scanner_type.return_value.scan_query.side_effect = regions
+        fragments = ds.fragments()
+        for fragment in fragments:
+            fragment.iter_batches()
+        assert len(fragments) == expected_count
+        if regions is not None and regions != ("*",):
+            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
+            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+                assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),
@@ -163,9 +176,20 @@ class TestBigBedFile:
         "regions",
         [("foo",), ("foo", "bar"), ("foo", "bar", "baz"), ("*",), None],
     )
-    def test_fragments(self, regions):
-        fragments = ox.BigBedFile("data/sample.bb", regions=regions).fragments()
-        assert len(fragments) == (len(regions) if regions else 1)
+    @mock.patch("oxbow._core.base.pa.RecordBatchReader")
+    def test_fragments(self, _, regions, mocker):
+        expected_count = 1 if regions is None else len(regions)
+        ds = ox.BigBedFile("data/sample.bb", regions=regions)
+        mock_scanner_type = mocker.patch.object(ds, "_scanner_type")
+        mock_scanner_type.return_value.scan_query.side_effect = regions
+        fragments = ds.fragments()
+        for fragment in fragments:
+            fragment.iter_batches()
+        assert len(fragments) == expected_count
+        if regions is not None and regions != ("*",):
+            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
+            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+                assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),
@@ -255,9 +279,20 @@ class TestBigWigFile:
         "regions",
         [("foo",), ("foo", "bar"), ("foo", "bar", "baz"), ("*",), None],
     )
-    def test_fragments(self, regions):
-        fragments = ox.BigWigFile("data/sample.bw", regions=regions).fragments()
-        assert len(fragments) == (len(regions) if regions else 1)
+    @mock.patch("oxbow._core.base.pa.RecordBatchReader")
+    def test_fragments(self, _, regions, mocker):
+        expected_count = 1 if regions is None else len(regions)
+        ds = ox.BigWigFile("data/sample.bw", regions=regions)
+        mock_scanner_type = mocker.patch.object(ds, "_scanner_type")
+        mock_scanner_type.return_value.scan_query.side_effect = regions
+        fragments = ds.fragments()
+        for fragment in fragments:
+            fragment.iter_batches()
+        assert len(fragments) == expected_count
+        if regions is not None and regions != ("*",):
+            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
+            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+                assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),
@@ -347,9 +382,20 @@ class TestGffFile:
         "regions",
         [("foo",), ("foo", "bar"), ("foo", "bar", "baz"), ("*",), None],
     )
-    def test_fragments(self, regions):
-        fragments = ox.GffFile("data/sample.gff", regions=regions).fragments()
-        assert len(fragments) == (len(regions) if regions else 1)
+    @mock.patch("oxbow._core.base.pa.RecordBatchReader")
+    def test_fragments(self, _, regions, mocker):
+        expected_count = 1 if regions is None else len(regions)
+        ds = ox.GffFile("data/sample.gff", regions=regions)
+        mock_scanner_type = mocker.patch.object(ds, "_scanner_type")
+        mock_scanner_type.return_value.scan_query.side_effect = regions
+        fragments = ds.fragments()
+        for fragment in fragments:
+            fragment.iter_batches()
+        assert len(fragments) == expected_count
+        if regions is not None and regions != ("*",):
+            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
+            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+                assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),
@@ -439,9 +485,20 @@ class TestGtfFile:
         "regions",
         [("foo",), ("foo", "bar"), ("foo", "bar", "baz"), ("*",), None],
     )
-    def test_fragments(self, regions):
-        fragments = ox.GtfFile("data/sample.gtf", regions=regions).fragments()
-        assert len(fragments) == (len(regions) if regions else 1)
+    @mock.patch("oxbow._core.base.pa.RecordBatchReader")
+    def test_fragments(self, _, regions, mocker):
+        expected_count = 1 if regions is None else len(regions)
+        ds = ox.GtfFile("data/sample.gtf", regions=regions)
+        mock_scanner_type = mocker.patch.object(ds, "_scanner_type")
+        mock_scanner_type.return_value.scan_query.side_effect = regions
+        fragments = ds.fragments()
+        for fragment in fragments:
+            fragment.iter_batches()
+        assert len(fragments) == expected_count
+        if regions is not None and regions != ("*",):
+            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
+            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+                assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),

--- a/py-oxbow/tests/test_feature.py
+++ b/py-oxbow/tests/test_feature.py
@@ -84,8 +84,12 @@ class TestBedFile:
             fragment.iter_batches()
         assert len(fragments) == expected_count
         if regions is not None and regions != ("*",):
-            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
-            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+            assert (
+                mock_scanner_type.return_value.scan_query.call_count == expected_count
+            )
+            for call, region in zip(
+                mock_scanner_type.return_value.scan_query.mock_calls, regions
+            ):
                 assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
@@ -187,8 +191,12 @@ class TestBigBedFile:
             fragment.iter_batches()
         assert len(fragments) == expected_count
         if regions is not None and regions != ("*",):
-            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
-            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+            assert (
+                mock_scanner_type.return_value.scan_query.call_count == expected_count
+            )
+            for call, region in zip(
+                mock_scanner_type.return_value.scan_query.mock_calls, regions
+            ):
                 assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
@@ -290,8 +298,12 @@ class TestBigWigFile:
             fragment.iter_batches()
         assert len(fragments) == expected_count
         if regions is not None and regions != ("*",):
-            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
-            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+            assert (
+                mock_scanner_type.return_value.scan_query.call_count == expected_count
+            )
+            for call, region in zip(
+                mock_scanner_type.return_value.scan_query.mock_calls, regions
+            ):
                 assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
@@ -393,8 +405,12 @@ class TestGffFile:
             fragment.iter_batches()
         assert len(fragments) == expected_count
         if regions is not None and regions != ("*",):
-            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
-            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+            assert (
+                mock_scanner_type.return_value.scan_query.call_count == expected_count
+            )
+            for call, region in zip(
+                mock_scanner_type.return_value.scan_query.mock_calls, regions
+            ):
                 assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(
@@ -496,8 +512,12 @@ class TestGtfFile:
             fragment.iter_batches()
         assert len(fragments) == expected_count
         if regions is not None and regions != ("*",):
-            assert mock_scanner_type.return_value.scan_query.call_count == expected_count
-            for call, region in zip(mock_scanner_type.return_value.scan_query.mock_calls, regions):
+            assert (
+                mock_scanner_type.return_value.scan_query.call_count == expected_count
+            )
+            for call, region in zip(
+                mock_scanner_type.return_value.scan_query.mock_calls, regions
+            ):
                 assert call.kwargs["region"] == region
 
     @pytest.mark.parametrize(

--- a/py-oxbow/tests/test_sequence.py
+++ b/py-oxbow/tests/test_sequence.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from pytest_manifest import Manifest
 
@@ -137,11 +139,22 @@ class TestFastaFile:
         "regions",
         [("foo",), ("foo", "bar"), ("foo", "bar", "baz"), ("*",), None],
     )
-    def test_fragments(self, regions):
-        fragments = ox.FastaFile(
-            "data/sample.fasta", index="data/sample.fai", regions=regions
-        ).fragments()
-        assert len(fragments) == 1
+    @mock.patch("oxbow._core.base.pa.RecordBatchReader")
+    def test_fragments(self, _, regions, mocker):
+        expected_count = 1
+        ds = ox.FastaFile("data/sample.fasta", index="data/sample.fai", regions=regions)
+        mock_scanner_type = mocker.patch.object(ds, "_scanner_type")
+        mock_scanner_type.return_value.scan_query.side_effect = regions
+        fragments = ds.fragments()
+        for fragment in fragments:
+            fragment.iter_batches()
+        assert len(fragments) == expected_count
+        if regions is not None and regions != ("*",):
+            assert (
+                mock_scanner_type.return_value.scan_query.call_count == expected_count
+            )
+            for call in mock_scanner_type.return_value.scan_query.mock_calls:
+                assert call.kwargs["regions"] == regions
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),
@@ -289,6 +302,7 @@ class TestFastqFile:
     def test_fragments(self):
         fragments = ox.FastqFile("data/sample.fastq").fragments()
         assert len(fragments) == 1
+    
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),

--- a/py-oxbow/tests/test_sequence.py
+++ b/py-oxbow/tests/test_sequence.py
@@ -302,7 +302,6 @@ class TestFastqFile:
     def test_fragments(self):
         fragments = ox.FastqFile("data/sample.fastq").fragments()
         assert len(fragments) == 1
-    
 
     @pytest.mark.parametrize(
         ("fields", "batch_size"),


### PR DESCRIPTION
Closures defined in a loop will end up using the final value of any loop-scoped variables they reference directly. This PR fixes the bug by implementing a factory function taking stream as an argument.