### PR TITLE
fix: Type coercion to i64 for integer tags and fallback string type

### DIFF
--- a/oxbow/src/alignment/model/batch_builder.rs
+++ b/oxbow/src/alignment/model/batch_builder.rs
@@ -157,24 +157,12 @@ impl Push<&noodles::sam::Record> for BatchBuilder {
             let data = record.data();
             for (def, builder) in self.tag_builders.iter_mut() {
                 let tag = Tag::from(def.into_bytes());
-                let ty = def.ty.noodles_type();
                 match data.get(&tag) {
                     // tag is present in this record
                     Some(result) => {
                         match result {
                             // tag parsed successfully
                             Ok(value) => {
-                                if value.ty() != ty {
-                                    return Err(io::Error::new(
-                                        io::ErrorKind::InvalidData,
-                                        format!(
-                                            "Type mismatch for tag {}; expected {:?}, got {:?}",
-                                            def.name,
-                                            ty,
-                                            value.ty()
-                                        ),
-                                    ));
-                                }
                                 builder.append_value(&value)?;
                             }
                             // tag could not be parsed
@@ -208,24 +196,12 @@ impl Push<&noodles::bam::Record> for BatchBuilder {
             let data = record.data();
             for (def, builder) in self.tag_builders.iter_mut() {
                 let tag = Tag::from(def.into_bytes());
-                let ty = def.ty.noodles_type();
                 match data.get(&tag) {
                     // tag is present in this record
                     Some(result) => {
                         match result {
                             // tag parsed successfully
                             Ok(value) => {
-                                if value.ty() != ty {
-                                    return Err(io::Error::new(
-                                        io::ErrorKind::InvalidData,
-                                        format!(
-                                            "Type mismatch for tag {}; expected {:?}, got {:?}",
-                                            def.name,
-                                            ty,
-                                            value.ty()
-                                        ),
-                                    ));
-                                }
                                 builder.append_value(&value)?;
                             }
                             // tag could not be parsed
@@ -279,7 +255,7 @@ mod tests {
         assert_eq!(schema.field(2).name(), "tags");
         assert_eq!(
             schema.field(2).data_type(),
-            &DataType::Struct(vec![ArrowField::new("NM", DataType::Int32, true)].into())
+            &DataType::Struct(vec![ArrowField::new("NM", DataType::Int64, true)].into())
         );
     }
 


### PR DESCRIPTION
Solves #107 

To deal with heterogeneity in integer tag types across records in the same file, we now represent all integer alignment tags in Arrow as `i64` which captures the entire range of tag integer values. Therefore, all tags definitions given as `c` (i8),`C` (u8), `s` (i16), `S` (u16), `i` (i32), `I` (u32) will be cast and returned as an arrow `Int64` column.

This PR also introduces type coercion from 8- and 16-bit integers to 32-bit float for tags definitions given as `f` upon encountering unexpected integers. I have seen this in practice, where a tag is sometimes a float and sometimes integer 0.

Finally, we provide a universal fallback if an alignment file's tag types for a given tag name are all over the place and fail to harmonize: defining the tag using the String code `Z` will convert all tag types to string (as long as they are successfully parsed by noodles). Then the user can decide how to handle the outputs.
