### PR TITLE
Make `BatchReaderFragment` a duck class and use internal batch size as default

### DIFF
--- a/py-oxbow/oxbow/_core/base.py
+++ b/py-oxbow/oxbow/_core/base.py
@@ -198,7 +198,7 @@ class DataSource:
         import polars as pl
 
         if lazy:
-            return pl.scan_pyarrow_dataset(self.dataset())
+            return pl.scan_pyarrow_dataset(self.dataset(), batch_size=self._batch_size)
         else:
             batches = list(self.batches())
             if not batches:

--- a/py-oxbow/oxbow/_pyarrow.py
+++ b/py-oxbow/oxbow/_pyarrow.py
@@ -66,6 +66,7 @@ class BatchReaderFragment:
         An expression that evaluates to true for all data viewed by this
         fragment.
     """
+
     def __init__(
         self,
         make_batchreader: Callable[[list[str] | None, int], RecordBatchIter],
@@ -366,10 +367,8 @@ class BatchReaderFragment:
         ).count_rows()
 
     def iter_batches(
-            self,
-            columns: list[str] | None = None,
-            batch_size: int | None = None
-        ) -> Iterator[pa.RecordBatch]:
+        self, columns: list[str] | None = None, batch_size: int | None = None
+    ) -> Iterator[pa.RecordBatch]:
         """
         Iterate over batches in the fragment.
 
@@ -630,10 +629,8 @@ class BatchReaderDataset(Dataset):
         ).to_batches()
 
     def iter_batches(
-            self,
-            columns: list[str] | None = None,
-            batch_size: int | None = None
-        ) -> Iterator[pa.RecordBatch]:
+        self, columns: list[str] | None = None, batch_size: int | None = None
+    ) -> Iterator[pa.RecordBatch]:
         """
         Iterate over batches in the dataset.
 


### PR DESCRIPTION
`BatchReaderFragment` objects are not pickleable, making them problematic to use for building dask partitions as they will fail in a multi-processing or distributed context. The two reasons they are not pickleable are:

1. PyScanners are not pickleable (fix in #112)
2. It derives from a cython extension class `pyarrow.dataset.Fragment`, which is not pickleable

This PR turns `BatchReaderFragment` into a duck class since it doesn't need to depend on deriving anything from `Fragment`, solving problem 2.

Additionally, this PR resolves a bug where the batch size provided to fragments at construction time is never used. All scanner-related methods on a fragment now use the internal batch size parameter by default. Datasets inherit the internal batch size parameter of their first fragment and use that by default.