### PR TITLE
feat: Expose certain scanner props to datasource

### DIFF
--- a/py-oxbow/oxbow/_core/alignment.py
+++ b/py-oxbow/oxbow/_core/alignment.py
@@ -97,6 +97,21 @@ class AlignmentFile(DataSource):
             **self._schema_kwargs,
         )
 
+    @property
+    def chrom_names(self) -> list[str]:
+        """List of reference sequence names declared in the header."""
+        return self.scanner().chrom_names()
+
+    @property
+    def chrom_sizes(self) -> list[tuple[str, int]]:
+        """List of reference sequence names and their lengths in bp."""
+        return self.scanner().chrom_sizes()
+
+    @property
+    def tag_defs(self) -> list[tuple[str, str]]:
+        """List of definitions for interpreting tag records."""
+        return self._schema_kwargs["tag_defs"]
+
 
 class SamFile(AlignmentFile):
     _scanner_type = PySamScanner

--- a/py-oxbow/oxbow/_core/bbi.py
+++ b/py-oxbow/oxbow/_core/bbi.py
@@ -58,7 +58,18 @@ class BbiFile(DataSource):
             yield self._batchreader_builder(scanner.scan, scanner.field_names())
 
     @property
+    def chrom_names(self) -> list[str]:
+        """List of reference sequence names."""
+        return self.scanner().chrom_names()
+
+    @property
+    def chrom_sizes(self) -> list[tuple[str, int]]:
+        """List of reference sequence names and their lengths in bp."""
+        return self.scanner().chrom_sizes()
+
+    @property
     def zoom_levels(self):
+        """List of zoom levels available."""
         return self.scanner().zoom_levels()
 
     def zoom(

--- a/py-oxbow/oxbow/_core/gxf.py
+++ b/py-oxbow/oxbow/_core/gxf.py
@@ -92,6 +92,11 @@ class GxfFile(DataSource):
             **self._schema_kwargs,
         )
 
+    @property
+    def attribute_defs(self) -> list[tuple[str, str]]:
+        """List of definitions for interpreting attribute records."""
+        return self._schema_kwargs["attribute_defs"]
+
 
 class GtfFile(GxfFile):
     _scanner_type = PyGtfScanner

--- a/py-oxbow/oxbow/_core/variant.py
+++ b/py-oxbow/oxbow/_core/variant.py
@@ -104,6 +104,31 @@ class VariantFile(DataSource):
             **self._schema_kwargs,
         )
 
+    @property
+    def chrom_names(self) -> list[str]:
+        """List of reference sequence names declared in the header."""
+        return self.scanner().chrom_names()
+
+    @property
+    def chrom_sizes(self) -> list[tuple[str, int]]:
+        """List of reference sequence names and their lengths in bp."""
+        return self.scanner().chrom_sizes()
+
+    @property
+    def info_field_defs(self) -> list[tuple[str, str, str]]:
+        """List of INFO field definitions in the VCF header."""
+        return self.scanner().info_field_defs()
+
+    @property
+    def genotype_field_defs(self) -> list[tuple[str, str, str]]:
+        """List of FORMAT field definitions in the VCF header."""
+        return self.scanner().genotype_field_defs()
+
+    @property
+    def samples(self) -> list[str]:
+        """List of sample IDs declared in the header."""
+        return self.scanner().sample_names()
+
 
 class VcfFile(VariantFile):
     _scanner_type = PyVcfScanner


### PR DESCRIPTION
Implements #101 

I did not implement any caching, except for tag/attribute defs, which are already cached. The overhead of file re-opening is not a big deal and we should be able to eliminate it in the future.

I also did not expose "field_names" for now, because we already have `columns` which includes them.
